### PR TITLE
Refactor of Filter section of Export Data page

### DIFF
--- a/source-code/mmria/mmria-server/Startup.cs
+++ b/source-code/mmria/mmria-server/Startup.cs
@@ -24,576 +24,585 @@ using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Authorization;
-using Microsoft.AspNetCore.Authentication;
+//using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Configuration.UserSecrets;
 using System.Security.Claims;
 using Newtonsoft.Json.Linq;
+using JavaScriptEngineSwitcher.ChakraCore;
+using JavaScriptEngineSwitcher.Extensions.MsDependencyInjection;
+using React.AspNet;
 
 
 namespace mmria.server
 {
-    public class Startup
+  public class Startup
+  {
+    public IConfiguration Configuration { get; }
+
+    public Startup(IConfiguration configuration)
     {
-        public IConfiguration Configuration { get; }
+      Configuration = configuration;
+    }
 
-        public Startup(IConfiguration configuration)
+    // This method gets called by the runtime. Use this method to add services to the container.
+    public void ConfigureServices(IServiceCollection services)
+    {
+      Program.DateOfLastChange_Sequence_Call = new List<DateTime>();
+      Program.Change_Sequence_Call_Count++;
+      Program.DateOfLastChange_Sequence_Call.Add(DateTime.Now);
+
+      Program.config_geocode_api_key = "";
+      Program.config_geocode_api_url = "";
+
+      if (!string.IsNullOrEmpty(Configuration["mmria_settings:is_schedule_enabled"]))
+      {
+        bool.TryParse(Configuration["mmria_settings:is_schedule_enabled"], out Program.is_schedule_enabled);
+      }
+
+      if (!string.IsNullOrEmpty(Configuration["mmria_settings:is_db_check_enabled"]))
+      {
+        bool.TryParse(Configuration["mmria_settings:is_db_check_enabled"], out Program.is_db_check_enabled);
+      }
+
+
+      if (!string.IsNullOrEmpty(Configuration["mmria_settings:app_instance_name"]))
+      {
+        Program.app_instance_name = Configuration["mmria_settings:app_instance_name"];
+      }
+
+      if (!string.IsNullOrEmpty(Configuration["mmria_settings:metadata_version"]))
+      {
+        Program.metadata_release_version_name = Configuration["mmria_settings:metadata_version"];
+      }
+
+
+      if (!string.IsNullOrEmpty(Configuration["mmria_settings:power_bi_link"]))
+      {
+        Program.power_bi_link = Configuration["mmria_settings:power_bi_link"];
+      }
+
+      if (!string.IsNullOrEmpty(Configuration["mmria_settings:db_prefix"]))
+      {
+        Program.db_prefix = Configuration["mmria_settings:db_prefix"];
+      }
+
+
+      var test_int = 0;
+      //Program.config_geocode_api_key = configuration["mmria_settings:geocode_api_key"];
+      //Program.config_geocode_api_url = configuration["mmria_settings:geocode_api_url"];
+      Program.config_couchdb_url = Configuration["mmria_settings:couchdb_url"];
+      Program.config_web_site_url = Configuration["mmria_settings:web_site_url"];
+      //Program.config_file_root_folder = configuration["mmria_settings:file_root_folder"];
+      Program.config_timer_user_name = Configuration["mmria_settings:timer_user_name"];
+      Program.config_timer_value = Configuration["mmria_settings:timer_password"];
+      Program.config_cron_schedule = Configuration["mmria_settings:cron_schedule"];
+      Program.config_export_directory = Configuration["mmria_settings:export_directory"];
+
+      Program.config_session_idle_timeout_minutes = Configuration["mmria_settings:session_idle_timeout"] != null && int.TryParse(Configuration["mmria_settings:session_idle_timeout"], out test_int) ? test_int : 30;
+
+
+      Program.config_pass_word_minimum_length = string.IsNullOrWhiteSpace(Configuration["password_settings:minimum_length"]) ? 8 : int.Parse(Configuration["password_settings:minimum_length"]);
+      Program.config_pass_word_days_before_expires = string.IsNullOrWhiteSpace(Configuration["password_settings:days_before_expires"]) ? 0 : int.Parse(Configuration["password_settings:days_before_expires"]);
+      Program.config_pass_word_days_before_user_is_notified_of_expiration = string.IsNullOrWhiteSpace(Configuration["password_settings:days_before_user_is_notified_of_expiration"]) ? 0 : int.Parse(Configuration["password_settings:days_before_user_is_notified_of_expiration"]);
+
+
+      /*
+      Program.config_EMAIL_USE_AUTHENTICATION = Configuration["mmria_settings:EMAIL_USE_AUTHENTICATION"];
+      Program.config_EMAIL_USE_SSL = Configuration["mmria_settings:EMAIL_USE_SSL"];
+      Program.config_SMTP_HOST = Configuration["mmria_settings:SMTP_HOST"];
+      Program.config_SMTP_PORT = Configuration["mmria_settings:SMTP_PORT"];
+      Program.config_EMAIL_FROM = Configuration["mmria_settings:EMAIL_FROM"];
+      Program.config_EMAIL_PASSWORD = Configuration["mmria_settings:EMAIL_PASSWORD"];
+      */
+      Program.config_default_days_in_effective_date_interval = string.IsNullOrWhiteSpace(Configuration["authentication_settings:default_days_in_effective_date_interval"]) ? 0 : int.Parse(Configuration["authentication_settings:default_days_in_effective_date_interval"]);
+      Program.config_unsuccessful_login_attempts_number_before_lockout = string.IsNullOrWhiteSpace(Configuration["authentication_settings:unsuccessful_login_attempts_number_before_lockout"]) ? 5 : int.Parse(Configuration["authentication_settings:unsuccessful_login_attempts_number_before_lockout"]);
+      Program.config_unsuccessful_login_attempts_within_number_of_minutes = string.IsNullOrWhiteSpace(Configuration["authentication_settings:unsuccessful_login_attempts_within_number_of_minutes"]) ? 120 : int.Parse(Configuration["authentication_settings:unsuccessful_login_attempts_within_number_of_minutes"]);
+      Program.config_unsuccessful_login_attempts_lockout_number_of_minutes = string.IsNullOrWhiteSpace(Configuration["authentication_settings:unsuccessful_login_attempts_lockout_number_of_minutes"]) ? 15 : int.Parse(Configuration["authentication_settings:unsuccessful_login_attempts_lockout_number_of_minutes"]);
+
+
+
+      if (bool.Parse(Configuration["mmria_settings:is_environment_based"]))
+      {
+        Log.Information("using Environment");
+
+
+        //Log.Information ("geocode_api_key: {0}", System.Environment.GetEnvironmentVariable ("geocode_api_key"));
+        //Log.Information ("geocode_api_url: {0}", System.Environment.GetEnvironmentVariable ("geocode_api_url"));
+        Log.Information("couchdb_url: {0}", System.Environment.GetEnvironmentVariable("couchdb_url"));
+        Log.Information("web_site_url: {0}", System.Environment.GetEnvironmentVariable("web_site_url"));
+        Log.Information("export_directory: {0}", System.Environment.GetEnvironmentVariable("export_directory"));
+
+        //Program.config_geocode_api_key = System.Environment.GetEnvironmentVariable ("geocode_api_key");
+        //Program.config_geocode_api_url = System.Environment.GetEnvironmentVariable ("geocode_api_url");
+        Program.config_couchdb_url = System.Environment.GetEnvironmentVariable("couchdb_url");
+        Program.config_web_site_url = System.Environment.GetEnvironmentVariable("web_site_url");
+        //Program.config_file_root_folder = System.Environment.GetEnvironmentVariable ("file_root_folder");
+        Program.config_timer_user_name = System.Environment.GetEnvironmentVariable("timer_user_name");
+        Program.config_timer_value = System.Environment.GetEnvironmentVariable("timer_password");
+        Program.config_cron_schedule = System.Environment.GetEnvironmentVariable("cron_schedule");
+        Program.config_export_directory = System.Environment.GetEnvironmentVariable("export_directory") != null ? System.Environment.GetEnvironmentVariable("export_directory") : "/workspace/export";
+
+        Configuration["mmria_settings:export_directory"] = Program.config_export_directory;
+
+
+        //
+
+        Program.config_session_idle_timeout_minutes = System.Environment.GetEnvironmentVariable("session_idle_timeout") != null && int.TryParse(System.Environment.GetEnvironmentVariable("session_idle_timeout"), out test_int) ? test_int : 30;
+
+
+        Program.config_pass_word_minimum_length = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("password_minimum_length")) ? 8 : int.Parse(System.Environment.GetEnvironmentVariable("password_minimum_length"));
+        Program.config_pass_word_days_before_expires = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("password_days_before_expires")) ? 0 : int.Parse(System.Environment.GetEnvironmentVariable("password_days_before_expires"));
+        Program.config_pass_word_days_before_user_is_notified_of_expiration = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("password_days_before_user_is_notified_of_expiration")) ? 0 : int.Parse(System.Environment.GetEnvironmentVariable("password_days_before_user_is_notified_of_expiration"));
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_endpoint_authorization")))
         {
-            Configuration = configuration;
+          Configuration["sams:endpoint_authorization"] = System.Environment.GetEnvironmentVariable("sams_endpoint_authorization");
         }
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("use_development_settings")))
         {
-            Program.DateOfLastChange_Sequence_Call = new List<DateTime> ();
-            Program.Change_Sequence_Call_Count++;
-            Program.DateOfLastChange_Sequence_Call.Add (DateTime.Now);
+          Configuration["mmria_settings:is_development"] = System.Environment.GetEnvironmentVariable("use_development_settings");
+        }
 
-            Program.config_geocode_api_key = "";
-            Program.config_geocode_api_url = "";
-
-            if(!string.IsNullOrEmpty(Configuration["mmria_settings:is_schedule_enabled"]))
-            {
-                bool.TryParse(Configuration["mmria_settings:is_schedule_enabled"], out Program.is_schedule_enabled);
-            }
-
-            if(!string.IsNullOrEmpty(Configuration["mmria_settings:is_db_check_enabled"]))
-            {
-                bool.TryParse(Configuration["mmria_settings:is_db_check_enabled"], out Program.is_db_check_enabled);
-            }
 
-
-            if(!string.IsNullOrEmpty(Configuration["mmria_settings:app_instance_name"]))
-            {
-                Program.app_instance_name = Configuration["mmria_settings:app_instance_name"];
-            }
-
-            if(!string.IsNullOrEmpty(Configuration["mmria_settings:metadata_version"]))
-            {
-                Program.metadata_release_version_name = Configuration["mmria_settings:metadata_version"];
-            }
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("metadata_version")))
+        {
+          Configuration["mmria_settings:metadata_version"] = System.Environment.GetEnvironmentVariable("metadata_version");
+          Program.metadata_release_version_name = System.Environment.GetEnvironmentVariable("metadata_version");
+        }
 
 
-            if(!string.IsNullOrEmpty(Configuration["mmria_settings:power_bi_link"]))
-            {
-                Program.power_bi_link = Configuration["mmria_settings:power_bi_link"];
-            }
-
-            if(!string.IsNullOrEmpty(Configuration["mmria_settings:db_prefix"]))
-            {
-                Program.db_prefix = Configuration["mmria_settings:db_prefix"];
-            }
-
-
-            var test_int = 0;
-            //Program.config_geocode_api_key = configuration["mmria_settings:geocode_api_key"];
-            //Program.config_geocode_api_url = configuration["mmria_settings:geocode_api_url"];
-            Program.config_couchdb_url = Configuration["mmria_settings:couchdb_url"];
-            Program.config_web_site_url = Configuration["mmria_settings:web_site_url"];
-            //Program.config_file_root_folder = configuration["mmria_settings:file_root_folder"];
-            Program.config_timer_user_name = Configuration["mmria_settings:timer_user_name"];
-            Program.config_timer_value = Configuration["mmria_settings:timer_password"];
-            Program.config_cron_schedule = Configuration["mmria_settings:cron_schedule"];
-            Program.config_export_directory = Configuration["mmria_settings:export_directory"];
-
-            Program.config_session_idle_timeout_minutes = Configuration["mmria_settings:session_idle_timeout"] != null && int.TryParse(Configuration["mmria_settings:session_idle_timeout"], out test_int) ? test_int : 30;
-
-
-            Program.config_pass_word_minimum_length = string.IsNullOrWhiteSpace(Configuration["password_settings:minimum_length"])? 8: int.Parse(Configuration["password_settings:minimum_length"]);
-            Program.config_pass_word_days_before_expires = string.IsNullOrWhiteSpace(Configuration["password_settings:days_before_expires"])? 0: int.Parse(Configuration["password_settings:days_before_expires"]);
-            Program.config_pass_word_days_before_user_is_notified_of_expiration = string.IsNullOrWhiteSpace(Configuration["password_settings:days_before_user_is_notified_of_expiration"])? 0: int.Parse(Configuration["password_settings:days_before_user_is_notified_of_expiration"]);
-            
-
-            /*
-            Program.config_EMAIL_USE_AUTHENTICATION = Configuration["mmria_settings:EMAIL_USE_AUTHENTICATION"];
-            Program.config_EMAIL_USE_SSL = Configuration["mmria_settings:EMAIL_USE_SSL"];
-            Program.config_SMTP_HOST = Configuration["mmria_settings:SMTP_HOST"];
-            Program.config_SMTP_PORT = Configuration["mmria_settings:SMTP_PORT"];
-            Program.config_EMAIL_FROM = Configuration["mmria_settings:EMAIL_FROM"];
-            Program.config_EMAIL_PASSWORD = Configuration["mmria_settings:EMAIL_PASSWORD"];
-            */
-            Program.config_default_days_in_effective_date_interval = string.IsNullOrWhiteSpace(Configuration["authentication_settings:default_days_in_effective_date_interval"])? 0: int.Parse(Configuration["authentication_settings:default_days_in_effective_date_interval"]);
-            Program.config_unsuccessful_login_attempts_number_before_lockout = string.IsNullOrWhiteSpace(Configuration["authentication_settings:unsuccessful_login_attempts_number_before_lockout"])? 5:int.Parse(Configuration["authentication_settings:unsuccessful_login_attempts_number_before_lockout"]);
-            Program.config_unsuccessful_login_attempts_within_number_of_minutes = string.IsNullOrWhiteSpace(Configuration["authentication_settings:unsuccessful_login_attempts_within_number_of_minutes"])? 120:int.Parse(Configuration["authentication_settings:unsuccessful_login_attempts_within_number_of_minutes"]);
-            Program.config_unsuccessful_login_attempts_lockout_number_of_minutes = string.IsNullOrWhiteSpace(Configuration["authentication_settings:unsuccessful_login_attempts_lockout_number_of_minutes"])? 15:int.Parse(Configuration["authentication_settings:unsuccessful_login_attempts_lockout_number_of_minutes"]);
-
-
-
-            if (bool.Parse (Configuration["mmria_settings:is_environment_based"])) 
-            {
-                Log.Information ("using Environment");
-
-                
-                //Log.Information ("geocode_api_key: {0}", System.Environment.GetEnvironmentVariable ("geocode_api_key"));
-                //Log.Information ("geocode_api_url: {0}", System.Environment.GetEnvironmentVariable ("geocode_api_url"));
-                Log.Information ("couchdb_url: {0}", System.Environment.GetEnvironmentVariable ("couchdb_url"));
-                Log.Information ("web_site_url: {0}", System.Environment.GetEnvironmentVariable ("web_site_url"));
-                Log.Information ("export_directory: {0}", System.Environment.GetEnvironmentVariable ("export_directory"));
-
-                //Program.config_geocode_api_key = System.Environment.GetEnvironmentVariable ("geocode_api_key");
-                //Program.config_geocode_api_url = System.Environment.GetEnvironmentVariable ("geocode_api_url");
-                Program.config_couchdb_url = System.Environment.GetEnvironmentVariable ("couchdb_url");
-                Program.config_web_site_url = System.Environment.GetEnvironmentVariable ("web_site_url");
-                //Program.config_file_root_folder = System.Environment.GetEnvironmentVariable ("file_root_folder");
-                Program.config_timer_user_name = System.Environment.GetEnvironmentVariable ("timer_user_name");
-                Program.config_timer_value = System.Environment.GetEnvironmentVariable ("timer_password");
-                Program.config_cron_schedule = System.Environment.GetEnvironmentVariable ("cron_schedule");
-                Program.config_export_directory = System.Environment.GetEnvironmentVariable ("export_directory") != null ? System.Environment.GetEnvironmentVariable ("export_directory") : "/workspace/export";
-
-                Configuration["mmria_settings:export_directory"] = Program.config_export_directory;
-
-
-                //
-
-                Program.config_session_idle_timeout_minutes = System.Environment.GetEnvironmentVariable ("session_idle_timeout") != null && int.TryParse(System.Environment.GetEnvironmentVariable ("session_idle_timeout"), out test_int) ? test_int : 30;
-
-
-                Program.config_pass_word_minimum_length = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("password_minimum_length"))? 8: int.Parse(System.Environment.GetEnvironmentVariable ("password_minimum_length"));
-                Program.config_pass_word_days_before_expires = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("password_days_before_expires"))? 0: int.Parse(System.Environment.GetEnvironmentVariable ("password_days_before_expires"));
-                Program.config_pass_word_days_before_user_is_notified_of_expiration = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("password_days_before_user_is_notified_of_expiration"))? 0: int.Parse(System.Environment.GetEnvironmentVariable ("password_days_before_user_is_notified_of_expiration"));
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_endpoint_authorization")))
-                {
-                    Configuration["sams:endpoint_authorization"] = System.Environment.GetEnvironmentVariable ("sams_endpoint_authorization");
-                }
-
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("use_development_settings")))
-                {
-                    Configuration["mmria_settings:is_development"] = System.Environment.GetEnvironmentVariable ("use_development_settings");
-                }
-                
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("metadata_version")))
-                {
-                    Configuration["mmria_settings:metadata_version"] = System.Environment.GetEnvironmentVariable ("metadata_version");
-                    Program.metadata_release_version_name = System.Environment.GetEnvironmentVariable ("metadata_version");
-                }
-
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_endpoint_token")))
-                {
-                    Configuration["sams:endpoint_token"] = System.Environment.GetEnvironmentVariable ("sams_endpoint_token");
-                }
-                
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_endpoint_user_info")))
-                {
-                    Configuration["sams:endpoint_user_info"] =  System.Environment.GetEnvironmentVariable ("sams_endpoint_user_info");
-                }
-                
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_endpoint_token_validation")))
-                {
-                    Configuration["sams:token_validation"] = System.Environment.GetEnvironmentVariable ("sams_endpoint_token_validation");
-                }
-                
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_endpoint_user_info_sys")))
-                {
-                    Configuration["sams:user_info_sys"] = System.Environment.GetEnvironmentVariable ("sams_endpoint_user_info_sys");
-                }
-                
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_client_id")))
-                {
-                    Configuration["sams:client_id"] = System.Environment.GetEnvironmentVariable ("sams_client_id");
-                }
-                
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_client_secret")))
-                {
-                    Configuration["sams:client_secret"] = System.Environment.GetEnvironmentVariable ("sams_client_secret");
-                }
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_callback_url")))
-                {
-                    Configuration["sams:callback_url"] = System.Environment.GetEnvironmentVariable ("sams_callback_url");
-                }
-            
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_logout_url")))
-                {
-                    Configuration["sams:logout_url"] = System.Environment.GetEnvironmentVariable ("sams_logout_url");
-                }
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("sams_is_enabled")))
-                {
-                    Configuration["sams:is_enabled"] = System.Environment.GetEnvironmentVariable ("sams_is_enabled");
-                }
-
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("is_schedule_enabled"))&& bool.TryParse(System.Environment.GetEnvironmentVariable ("is_schedule_enabled"), out Program.is_schedule_enabled))
-                {
-                    Configuration["is_schedule_enabled"] = System.Environment.GetEnvironmentVariable ("is_schedule_enabled");
-                }
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("is_db_check_enabled"))&& bool.TryParse(System.Environment.GetEnvironmentVariable ("is_db_check_enabled"), out Program.is_db_check_enabled))
-                {
-                    Configuration["is_db_check_enabled"] = System.Environment.GetEnvironmentVariable ("is_db_check_enabled");
-                }
-
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("app_instance_name")))
-                {
-                    Configuration["mmria_settings:app_instance_name"] = System.Environment.GetEnvironmentVariable ("app_instance_name");
-                    Program.app_instance_name = Configuration["mmria_settings:app_instance_name"];
-                }
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("power_bi_link")))
-                {
-                    Configuration["mmria_settings:power_bi_link"] = System.Environment.GetEnvironmentVariable ("power_bi_link");
-                    Program.power_bi_link = Configuration["mmria_settings:power_bi_link"];
-                }
-
-
-                if(!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("db_prefix")))
-                {
-                    Configuration["mmria_settings:db_prefix"] = System.Environment.GetEnvironmentVariable ("db_prefix");
-                    Program.db_prefix = Configuration["mmria_settings:db_prefix"];
-                }
-
-                /*
-                Program.config_EMAIL_USE_AUTHENTICATION = System.Environment.GetEnvironmentVariable ("EMAIL_USE_AUTHENTICATION"); //  = true;
-                Program.config_EMAIL_USE_SSL = System.Environment.GetEnvironmentVariable ("EMAIL_USE_SSL"); //  = true;
-                Program.config_SMTP_HOST = System.Environment.GetEnvironmentVariable ("SMTP_HOST"); //  = null;
-                Program.config_SMTP_PORT = System.Environment.GetEnvironmentVariable ("SMTP_PORT"); //  = 587;
-                Program.config_EMAIL_FROM = System.Environment.GetEnvironmentVariable ("EMAIL_FROM"); //  = null;
-                Program.config_EMAIL_PASSWORD = System.Environment.GetEnvironmentVariable ("EMAIL_PASSWORD"); //  = null;
-                */
-                Program.config_default_days_in_effective_date_interval = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("default_days_in_effective_date_interval"))? 90:int.Parse(System.Environment.GetEnvironmentVariable ("default_days_in_effective_date_interval"));
-                Program.config_unsuccessful_login_attempts_number_before_lockout = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("unsuccessful_login_attempts_number_before_lockout"))? 5:int.Parse(System.Environment.GetEnvironmentVariable ("unsuccessful_login_attempts_number_before_lockout"));
-                Program.config_unsuccessful_login_attempts_within_number_of_minutes = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("unsuccessful_login_attempts_within_number_of_minutes"))? 120:int.Parse(System.Environment.GetEnvironmentVariable ("unsuccessful_login_attempts_within_number_of_minutes"));
-                Program.config_unsuccessful_login_attempts_lockout_number_of_minutes = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable ("unsuccessful_login_attempts_lockout_number_of_minutes"))? 15:int.Parse(System.Environment.GetEnvironmentVariable ("unsuccessful_login_attempts_lockout_number_of_minutes"));
-
-            }
-
-
-
-            Log.Information($"Program.config_timer_user_name = {Program.config_timer_user_name}");
-            Log.Information($"Program.config_couchdb_url = {Program.config_couchdb_url}");
-            Log.Information($"Program.db_prefix = {Program.db_prefix}");
-            Log.Information($"Logging = {Configuration["Logging:IncludeScopes"]}");
-            Log.Information($"Console = {Configuration["Console:LogLevel:Default"]}");
-            Log.Information ("sams:callback_url: {0}", Configuration["sams:callback_url"]);
-            Log.Information ("sams:activity_name: {0}", Configuration["sams:activity_name"]);
-            Log.Information ("mmria_settings:is_schedule_enabled: {0}", Configuration["mmria_settings:is_schedule_enabled"]);
-            Log.Information ("mmria_settings:is_db_check_enabled: {0}", Configuration["mmria_settings:is_db_check_enabled"]);
-            Log.Information ("mmria_settings:is_development: {0}", Configuration["mmria_settings:is_development"]);
-            Log.Information ("mmria_settings:metadata_version: {0}", Configuration["mmria_settings:metadata_version"]);
-            Log.Information ("mmria_settings:power_bi_link: {0}", Configuration["mmria_settings:power_bi_link"]);
-            Log.Information ("mmria_settings:app_instance_name: {0}", Configuration["mmria_settings:app_instance_name"]);
-
-
-
-            Program.actorSystem = ActorSystem.Create("mmria-actor-system");
-            services.AddSingleton(typeof(ActorSystem), (serviceProvider) => Program.actorSystem);
-
-            ISchedulerFactory schedFact = new StdSchedulerFactory();
-            Quartz.IScheduler sched = schedFact.GetScheduler().Result;
-
-            // compute a time that is on the next round minute
-            DateTimeOffset runTime = DateBuilder.EvenMinuteDate(DateTimeOffset.UtcNow);
-
-            // define the job and tie it to our HelloJob class
-            IJobDetail job = JobBuilder.Create< mmria.server.model.Pulse_job>()
-                .WithIdentity("job1", "group1")
-                .Build();
-
-            // Trigger the job to run on the next round minute
-            ITrigger trigger = TriggerBuilder.Create()
-                .WithIdentity("trigger1", "group1")
-                .StartAt(runTime.AddMinutes(3))
-                .WithCronSchedule (Program.config_cron_schedule)
-                .Build();
-
-            sched.ScheduleJob(job, trigger);
-
-            if(Program.is_schedule_enabled)
-            {
-                sched.Start();
-            }
-            
-            /*
-            Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Check_DB_Install>(), "Check_DB_Install");
-            Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Rebuild_Export_Queue>(), "Rebuild_Export_Queue");
-            Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Process_Export_Queue>(), "Process_Export_Queue");
-            Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Process_Migrate_Data>(), "Process_Migrate_Data");
-            Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.Synchronize_Case>(), "case_sync_actor");
-            */
-            //Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Process_Migrate_Data>(), "Process_Migrate_Data");
-
-            var quartzSupervisor = Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.QuartzSupervisor>(), "QuartzSupervisor");
-
-            //System.Threading.Thread.Sleep(1000);
-
-            quartzSupervisor.Tell("init");
-
-            var use_sams = false;
-            
-            if(!string.IsNullOrWhiteSpace(Configuration["sams:is_enabled"]))
-            {
-                bool.TryParse(Configuration["sams:is_enabled"], out use_sams);
-            }
-
-/*
-            //https://docs.microsoft.com/en-us/aspnet/core/fundamentals/app-state?view=aspnetcore-2.2
-            services.AddDistributedMemoryCache();
-            services.AddSession(opts =>
-            {
-                opts.Cookie.HttpOnly = true;
-                opts.Cookie.Name = ".mmria.session";
-                opts.IdleTimeout = TimeSpan.FromMinutes(Program.config_session_idle_timeout_minutes);
-            });
- */
-            if(use_sams)
-            {
-                Log.Information ("using sams");
-
-                if(Configuration["mmria_settings:is_development"]!= null && Configuration["mmria_settings:is_development"] == "true")
-                {
-
-                    Log.Information ("using sams and is_development");
-                    //https://github.com/jerriepelser-blog/AspnetCoreGitHubAuth/blob/master/AspNetCoreGitHubAuth/
-
-                    services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-                    .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme,
-                        options => 
-                        {
-                                options.LoginPath = new PathString("/Account/SignIn");
-                                options.AccessDeniedPath = new PathString("/Account/Forbidden/");
-                                options.Cookie.SameSite = SameSiteMode.Strict;
-                                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
-
-                                options.Events = get_sams_authentication_events();
-
-                                Log.Information ("options.Cookie.SameSite: {0}", options.Cookie.SameSite);
-                                Log.Information ("options.Cookie.SecurePolicy: {0}", options.Cookie.SecurePolicy);
-
-
-                        });
-                        /*
-                        .AddOAuth("SAMS", options =>
-                        {
-                            options.ClientId = Configuration["sams:client_id"];
-                            options.ClientSecret = Configuration["sams:client_secret"];
-                            options.CallbackPath = new PathString("/Account/SignInCallback");//new PathString(Configuration["sams:callback_url"]);// new PathString("/signin-github");
-
-                            options.AuthorizationEndpoint = Configuration["sams:endpoint_authorization"];// "https://github.com/login/oauth/authorize";
-                            options.TokenEndpoint = Configuration["sams:endpoint_token"];// ""https://github.com/login/oauth/access_token";
-                            options.UserInformationEndpoint = Configuration["sams:endpoint_user_info"];// "https://api.github.com/user";
-
-                            options.SaveTokens = true;
-
-                            options.ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
-                            options.ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
-                            options.ClaimActions.MapJsonKey("urn:github:login", "login");
-                            options.ClaimActions.MapJsonKey("urn:github:url", "html_url");
-                            options.ClaimActions.MapJsonKey("urn:github:avatar", "avatar_url");
-
-                            options.Events = new OAuthEvents
-                            {
-                                OnCreatingTicket = async context =>
-                                {
-                                    var request = new HttpRequestMessage(HttpMethod.Get, context.Options.UserInformationEndpoint);
-                                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", context.AccessToken);
-
-                                    var response = await context.Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, context.HttpContext.RequestAborted);
-                                    response.EnsureSuccessStatusCode();
-
-                                    var user = JObject.Parse(await response.Content.ReadAsStringAsync());
-
-                                    context.RunClaimActions(user);
-                                }
-                            };
-                    }); */
-                        
-                }
-                else
-                {
-                    Log.Information ("using sams and NOT is_development");
-
-                    services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-                    .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme,
-                        options => 
-                        {
-                                options.LoginPath = new PathString("/Account/SignIn");
-                                options.AccessDeniedPath = new PathString("/Account/Forbidden/");
-                                options.Cookie.SameSite = SameSiteMode.Strict;
-                                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
-                               options.Events = get_sams_authentication_events();
-
-                                Log.Information ("options.Cookie.SameSite: {0}", options.Cookie.SameSite);
-                                Log.Information ("options.Cookie.SecurePolicy: {0}", options.Cookie.SecurePolicy);
-
-
-                        });
-                        /*
-                        .AddOAuth("SAMS", options =>
-                        {
-                            options.ClientId = Configuration["sams:client_id"];
-                            options.ClientSecret = Configuration["sams:client_secret"];
-                            options.CallbackPath = Configuration["sams:callback_url"];// new PathString("/signin-github");
-
-                            options.AuthorizationEndpoint = Configuration["sams:endpoint_authorization"];// "https://github.com/login/oauth/authorize";
-                            options.TokenEndpoint = Configuration["sams:endpoint_token"];// ""https://github.com/login/oauth/access_token";
-                            options.UserInformationEndpoint = Configuration["sams:endpoint_user_info"];// "https://api.github.com/user";
-
-                            options.SaveTokens = true;
-
-                            options.ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
-                            options.ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
-                            options.ClaimActions.MapJsonKey("urn:github:login", "login");
-                            options.ClaimActions.MapJsonKey("urn:github:url", "html_url");
-                            options.ClaimActions.MapJsonKey("urn:github:avatar", "avatar_url");
-
-                            options.Events = new OAuthEvents
-                            {
-                                OnCreatingTicket = async context =>
-                                {
-                                    var request = new HttpRequestMessage(HttpMethod.Get, context.Options.UserInformationEndpoint);
-                                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", context.AccessToken);
-
-                                    var response = await context.Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, context.HttpContext.RequestAborted);
-                                    response.EnsureSuccessStatusCode();
-
-                                    var user = JObject.Parse(await response.Content.ReadAsStringAsync());
-
-                                    context.RunClaimActions(user);
-                                }
-                            };
-                    }); */
-                }
-                
-            }
-            else
-            {
-                Log.Information ("NOT using sams");
-
-                if(Configuration["mmria_settings:is_development"]!= null && Configuration["mmria_settings:is_development"] == "true")
-                {
-                    Log.Information ("is_development == true");
-                    services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-                        .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme,
-                        options => 
-                        {
-                                options.LoginPath = new PathString("/Account/Login/");
-                                options.AccessDeniedPath = new PathString("/Account/Forbidden/");
-
-                                options.Cookie.SameSite = SameSiteMode.Strict;
-                                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
-
-
-                                Log.Information ("options.Cookie.SameSite: {0}", options.Cookie.SameSite);
-                                Log.Information ("options.Cookie.SecurePolicy: {0}", options.Cookie.SecurePolicy);
-                        });
-                }
-                else
-                {
-                    Log.Information ("is_development == false");
-
-                    services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-                        .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme,
-                        options => 
-                        {
-                                options.LoginPath = new PathString("/Account/Login/");
-                                options.AccessDeniedPath = new PathString("/Account/Forbidden/");
-                                options.Cookie.SameSite = SameSiteMode.Strict;
-                                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
-
-                               Log.Information ("options.Cookie.SameSite: {0}", options.Cookie.SameSite);
-                                Log.Information ("options.Cookie.SecurePolicy: {0}", options.Cookie.SecurePolicy);
-                        });
-                }
-            }
-            
-
-
-            services.AddAuthorization(options =>
-            {
-                //options.AddPolicy("AdministratorOnly", policy => policy.RequireRole("Administrator"));
-                options.AddPolicy("abstractor", policy => policy.RequireRole("abstractor"));
-                options.AddPolicy("form_designer", policy => policy.RequireRole("form_designer"));
-                options.AddPolicy("committee_member", policy => policy.RequireRole("committee_member"));
-                options.AddPolicy("jurisdiction_admin", policy => policy.RequireRole("jurisdiction_admin"));
-                options.AddPolicy("installation_admin", policy => policy.RequireRole("installation_admin"));
-                options.AddPolicy("guest", policy => policy.RequireRole("guest"));
-
-                //options.AddPolicy("form_designer", policy => policy.RequireClaim("EmployeeId"));
-                //options.AddPolicy("EmployeeId", policy => policy.RequireClaim("EmployeeId", "123", "456"));
-                //options.AddPolicy("Over21Only", policy => policy.Requirements.Add(new MinimumAgeRequirement(21)));
-                //options.AddPolicy("BuildingEntry", policy => policy.Requirements.Add(new OfficeEntryRequirement()));
-                
-            });            
-
-            services.AddMvc(config =>
-            {
-                var policy = new AuthorizationPolicyBuilder()
-                                .RequireAuthenticatedUser()
-                                .Build();
-                config.Filters.Add(new AuthorizeFilter(policy));
-
-                config.CacheProfiles.Add("NoStore",
-                new Microsoft.AspNetCore.Mvc.CacheProfile()
-                {
-                    NoStore = true
-                });
-            });
-            /*.AddJsonOptions(o =>
-                {
-                    o.JsonSerializerOptions.PropertyNamingPolicy = null;
-                    o.JsonSerializerOptions.DictionaryKeyPolicy = null;
-                });
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_endpoint_token")))
+        {
+          Configuration["sams:endpoint_token"] = System.Environment.GetEnvironmentVariable("sams_endpoint_token");
+        }
+
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_endpoint_user_info")))
+        {
+          Configuration["sams:endpoint_user_info"] = System.Environment.GetEnvironmentVariable("sams_endpoint_user_info");
+        }
+
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_endpoint_token_validation")))
+        {
+          Configuration["sams:token_validation"] = System.Environment.GetEnvironmentVariable("sams_endpoint_token_validation");
+        }
+
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_endpoint_user_info_sys")))
+        {
+          Configuration["sams:user_info_sys"] = System.Environment.GetEnvironmentVariable("sams_endpoint_user_info_sys");
+        }
+
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_client_id")))
+        {
+          Configuration["sams:client_id"] = System.Environment.GetEnvironmentVariable("sams_client_id");
+        }
+
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_client_secret")))
+        {
+          Configuration["sams:client_secret"] = System.Environment.GetEnvironmentVariable("sams_client_secret");
+        }
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_callback_url")))
+        {
+          Configuration["sams:callback_url"] = System.Environment.GetEnvironmentVariable("sams_callback_url");
+        }
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_logout_url")))
+        {
+          Configuration["sams:logout_url"] = System.Environment.GetEnvironmentVariable("sams_logout_url");
+        }
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("sams_is_enabled")))
+        {
+          Configuration["sams:is_enabled"] = System.Environment.GetEnvironmentVariable("sams_is_enabled");
+        }
+
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("is_schedule_enabled")) && bool.TryParse(System.Environment.GetEnvironmentVariable("is_schedule_enabled"), out Program.is_schedule_enabled))
+        {
+          Configuration["is_schedule_enabled"] = System.Environment.GetEnvironmentVariable("is_schedule_enabled");
+        }
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("is_db_check_enabled")) && bool.TryParse(System.Environment.GetEnvironmentVariable("is_db_check_enabled"), out Program.is_db_check_enabled))
+        {
+          Configuration["is_db_check_enabled"] = System.Environment.GetEnvironmentVariable("is_db_check_enabled");
+        }
+
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("app_instance_name")))
+        {
+          Configuration["mmria_settings:app_instance_name"] = System.Environment.GetEnvironmentVariable("app_instance_name");
+          Program.app_instance_name = Configuration["mmria_settings:app_instance_name"];
+        }
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("power_bi_link")))
+        {
+          Configuration["mmria_settings:power_bi_link"] = System.Environment.GetEnvironmentVariable("power_bi_link");
+          Program.power_bi_link = Configuration["mmria_settings:power_bi_link"];
+        }
+
+
+        if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("db_prefix")))
+        {
+          Configuration["mmria_settings:db_prefix"] = System.Environment.GetEnvironmentVariable("db_prefix");
+          Program.db_prefix = Configuration["mmria_settings:db_prefix"];
+        }
+
+        /*
+        Program.config_EMAIL_USE_AUTHENTICATION = System.Environment.GetEnvironmentVariable ("EMAIL_USE_AUTHENTICATION"); //  = true;
+        Program.config_EMAIL_USE_SSL = System.Environment.GetEnvironmentVariable ("EMAIL_USE_SSL"); //  = true;
+        Program.config_SMTP_HOST = System.Environment.GetEnvironmentVariable ("SMTP_HOST"); //  = null;
+        Program.config_SMTP_PORT = System.Environment.GetEnvironmentVariable ("SMTP_PORT"); //  = 587;
+        Program.config_EMAIL_FROM = System.Environment.GetEnvironmentVariable ("EMAIL_FROM"); //  = null;
+        Program.config_EMAIL_PASSWORD = System.Environment.GetEnvironmentVariable ("EMAIL_PASSWORD"); //  = null;
+        */
+        Program.config_default_days_in_effective_date_interval = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("default_days_in_effective_date_interval")) ? 90 : int.Parse(System.Environment.GetEnvironmentVariable("default_days_in_effective_date_interval"));
+        Program.config_unsuccessful_login_attempts_number_before_lockout = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("unsuccessful_login_attempts_number_before_lockout")) ? 5 : int.Parse(System.Environment.GetEnvironmentVariable("unsuccessful_login_attempts_number_before_lockout"));
+        Program.config_unsuccessful_login_attempts_within_number_of_minutes = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("unsuccessful_login_attempts_within_number_of_minutes")) ? 120 : int.Parse(System.Environment.GetEnvironmentVariable("unsuccessful_login_attempts_within_number_of_minutes"));
+        Program.config_unsuccessful_login_attempts_lockout_number_of_minutes = string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("unsuccessful_login_attempts_lockout_number_of_minutes")) ? 15 : int.Parse(System.Environment.GetEnvironmentVariable("unsuccessful_login_attempts_lockout_number_of_minutes"));
+
+      }
+
+
+
+      Log.Information($"Program.config_timer_user_name = {Program.config_timer_user_name}");
+      Log.Information($"Program.config_couchdb_url = {Program.config_couchdb_url}");
+      Log.Information($"Program.db_prefix = {Program.db_prefix}");
+      Log.Information($"Logging = {Configuration["Logging:IncludeScopes"]}");
+      Log.Information($"Console = {Configuration["Console:LogLevel:Default"]}");
+      Log.Information("sams:callback_url: {0}", Configuration["sams:callback_url"]);
+      Log.Information("sams:activity_name: {0}", Configuration["sams:activity_name"]);
+      Log.Information("mmria_settings:is_schedule_enabled: {0}", Configuration["mmria_settings:is_schedule_enabled"]);
+      Log.Information("mmria_settings:is_db_check_enabled: {0}", Configuration["mmria_settings:is_db_check_enabled"]);
+      Log.Information("mmria_settings:is_development: {0}", Configuration["mmria_settings:is_development"]);
+      Log.Information("mmria_settings:metadata_version: {0}", Configuration["mmria_settings:metadata_version"]);
+      Log.Information("mmria_settings:power_bi_link: {0}", Configuration["mmria_settings:power_bi_link"]);
+      Log.Information("mmria_settings:app_instance_name: {0}", Configuration["mmria_settings:app_instance_name"]);
+
+
+
+      Program.actorSystem = ActorSystem.Create("mmria-actor-system");
+      services.AddSingleton(typeof(ActorSystem), (serviceProvider) => Program.actorSystem);
+
+      ISchedulerFactory schedFact = new StdSchedulerFactory();
+      Quartz.IScheduler sched = schedFact.GetScheduler().Result;
+
+      // compute a time that is on the next round minute
+      DateTimeOffset runTime = DateBuilder.EvenMinuteDate(DateTimeOffset.UtcNow);
+
+      // define the job and tie it to our HelloJob class
+      IJobDetail job = JobBuilder.Create<mmria.server.model.Pulse_job>()
+          .WithIdentity("job1", "group1")
+          .Build();
+
+      // Trigger the job to run on the next round minute
+      ITrigger trigger = TriggerBuilder.Create()
+          .WithIdentity("trigger1", "group1")
+          .StartAt(runTime.AddMinutes(3))
+          .WithCronSchedule(Program.config_cron_schedule)
+          .Build();
+
+      sched.ScheduleJob(job, trigger);
+
+      if (Program.is_schedule_enabled)
+      {
+        sched.Start();
+      }
+
+      /*
+      Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Check_DB_Install>(), "Check_DB_Install");
+      Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Rebuild_Export_Queue>(), "Rebuild_Export_Queue");
+      Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Process_Export_Queue>(), "Process_Export_Queue");
+      Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Process_Migrate_Data>(), "Process_Migrate_Data");
+      Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.Synchronize_Case>(), "case_sync_actor");
+      */
+      //Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.quartz.Process_Migrate_Data>(), "Process_Migrate_Data");
+
+      var quartzSupervisor = Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.QuartzSupervisor>(), "QuartzSupervisor");
+
+      //System.Threading.Thread.Sleep(1000);
+
+      quartzSupervisor.Tell("init");
+
+      var use_sams = false;
+
+      if (!string.IsNullOrWhiteSpace(Configuration["sams:is_enabled"]))
+      {
+        bool.TryParse(Configuration["sams:is_enabled"], out use_sams);
+      }
+
+      /*
+                  //https://docs.microsoft.com/en-us/aspnet/core/fundamentals/app-state?view=aspnetcore-2.2
+                  services.AddDistributedMemoryCache();
+                  services.AddSession(opts =>
+                  {
+                      opts.Cookie.HttpOnly = true;
+                      opts.Cookie.Name = ".mmria.session";
+                      opts.IdleTimeout = TimeSpan.FromMinutes(Program.config_session_idle_timeout_minutes);
+                  });
+       */
+      if (use_sams)
+      {
+        Log.Information("using sams");
+
+        if (Configuration["mmria_settings:is_development"] != null && Configuration["mmria_settings:is_development"] == "true")
+        {
+
+          Log.Information("using sams and is_development");
+          //https://github.com/jerriepelser-blog/AspnetCoreGitHubAuth/blob/master/AspNetCoreGitHubAuth/
+
+          services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+          .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme,
+              options =>
+              {
+                options.LoginPath = new PathString("/Account/SignIn");
+                options.AccessDeniedPath = new PathString("/Account/Forbidden/");
+                options.Cookie.SameSite = SameSiteMode.Strict;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+
+                options.Events = get_sams_authentication_events();
+
+                Log.Information("options.Cookie.SameSite: {0}", options.Cookie.SameSite);
+                Log.Information("options.Cookie.SecurePolicy: {0}", options.Cookie.SecurePolicy);
+
+
+              });
+          /*
+          .AddOAuth("SAMS", options =>
+          {
+              options.ClientId = Configuration["sams:client_id"];
+              options.ClientSecret = Configuration["sams:client_secret"];
+              options.CallbackPath = new PathString("/Account/SignInCallback");//new PathString(Configuration["sams:callback_url"]);// new PathString("/signin-github");
+
+              options.AuthorizationEndpoint = Configuration["sams:endpoint_authorization"];// "https://github.com/login/oauth/authorize";
+              options.TokenEndpoint = Configuration["sams:endpoint_token"];// ""https://github.com/login/oauth/access_token";
+              options.UserInformationEndpoint = Configuration["sams:endpoint_user_info"];// "https://api.github.com/user";
+
+              options.SaveTokens = true;
+
+              options.ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
+              options.ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
+              options.ClaimActions.MapJsonKey("urn:github:login", "login");
+              options.ClaimActions.MapJsonKey("urn:github:url", "html_url");
+              options.ClaimActions.MapJsonKey("urn:github:avatar", "avatar_url");
+
+              options.Events = new OAuthEvents
+              {
+                  OnCreatingTicket = async context =>
+                  {
+                      var request = new HttpRequestMessage(HttpMethod.Get, context.Options.UserInformationEndpoint);
+                      request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                      request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", context.AccessToken);
+
+                      var response = await context.Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, context.HttpContext.RequestAborted);
+                      response.EnsureSuccessStatusCode();
+
+                      var user = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+                      context.RunClaimActions(user);
+                  }
+              };
+      }); */
+
+        }
+        else
+        {
+          Log.Information("using sams and NOT is_development");
+
+          services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+          .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme,
+              options =>
+              {
+                options.LoginPath = new PathString("/Account/SignIn");
+                options.AccessDeniedPath = new PathString("/Account/Forbidden/");
+                options.Cookie.SameSite = SameSiteMode.Strict;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+                options.Events = get_sams_authentication_events();
+
+                Log.Information("options.Cookie.SameSite: {0}", options.Cookie.SameSite);
+                Log.Information("options.Cookie.SecurePolicy: {0}", options.Cookie.SecurePolicy);
+
+
+              });
+          /*
+          .AddOAuth("SAMS", options =>
+          {
+              options.ClientId = Configuration["sams:client_id"];
+              options.ClientSecret = Configuration["sams:client_secret"];
+              options.CallbackPath = Configuration["sams:callback_url"];// new PathString("/signin-github");
+
+              options.AuthorizationEndpoint = Configuration["sams:endpoint_authorization"];// "https://github.com/login/oauth/authorize";
+              options.TokenEndpoint = Configuration["sams:endpoint_token"];// ""https://github.com/login/oauth/access_token";
+              options.UserInformationEndpoint = Configuration["sams:endpoint_user_info"];// "https://api.github.com/user";
+
+              options.SaveTokens = true;
+
+              options.ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
+              options.ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
+              options.ClaimActions.MapJsonKey("urn:github:login", "login");
+              options.ClaimActions.MapJsonKey("urn:github:url", "html_url");
+              options.ClaimActions.MapJsonKey("urn:github:avatar", "avatar_url");
+
+              options.Events = new OAuthEvents
+              {
+                  OnCreatingTicket = async context =>
+                  {
+                      var request = new HttpRequestMessage(HttpMethod.Get, context.Options.UserInformationEndpoint);
+                      request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                      request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", context.AccessToken);
+
+                      var response = await context.Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, context.HttpContext.RequestAborted);
+                      response.EnsureSuccessStatusCode();
+
+                      var user = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+                      context.RunClaimActions(user);
+                  }
+              };
+      }); */
+        }
+
+      }
+      else
+      {
+        Log.Information("NOT using sams");
+
+        if (Configuration["mmria_settings:is_development"] != null && Configuration["mmria_settings:is_development"] == "true")
+        {
+          Log.Information("is_development == true");
+          services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+              .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme,
+              options =>
+              {
+                options.LoginPath = new PathString("/Account/Login/");
+                options.AccessDeniedPath = new PathString("/Account/Forbidden/");
+
+                options.Cookie.SameSite = SameSiteMode.Strict;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+
+
+                Log.Information("options.Cookie.SameSite: {0}", options.Cookie.SameSite);
+                Log.Information("options.Cookie.SecurePolicy: {0}", options.Cookie.SecurePolicy);
+              });
+        }
+        else
+        {
+          Log.Information("is_development == false");
+
+          services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+              .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme,
+              options =>
+              {
+                options.LoginPath = new PathString("/Account/Login/");
+                options.AccessDeniedPath = new PathString("/Account/Forbidden/");
+                options.Cookie.SameSite = SameSiteMode.Strict;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+
+                Log.Information("options.Cookie.SameSite: {0}", options.Cookie.SameSite);
+                Log.Information("options.Cookie.SecurePolicy: {0}", options.Cookie.SecurePolicy);
+              });
+        }
+      }
+
+
+
+      services.AddAuthorization(options =>
+      {
+        //options.AddPolicy("AdministratorOnly", policy => policy.RequireRole("Administrator"));
+        options.AddPolicy("abstractor", policy => policy.RequireRole("abstractor"));
+        options.AddPolicy("form_designer", policy => policy.RequireRole("form_designer"));
+        options.AddPolicy("committee_member", policy => policy.RequireRole("committee_member"));
+        options.AddPolicy("jurisdiction_admin", policy => policy.RequireRole("jurisdiction_admin"));
+        options.AddPolicy("installation_admin", policy => policy.RequireRole("installation_admin"));
+        options.AddPolicy("guest", policy => policy.RequireRole("guest"));
+
+        //options.AddPolicy("form_designer", policy => policy.RequireClaim("EmployeeId"));
+        //options.AddPolicy("EmployeeId", policy => policy.RequireClaim("EmployeeId", "123", "456"));
+        //options.AddPolicy("Over21Only", policy => policy.Requirements.Add(new MinimumAgeRequirement(21)));
+        //options.AddPolicy("BuildingEntry", policy => policy.Requirements.Add(new OfficeEntryRequirement()));
+
+      });
+      //services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+      services.AddReact();
+
+      // Make sure a JS engine is registered, or you will get an error!
+      services.AddJsEngineSwitcher(options => options.DefaultEngineName = ChakraCoreJsEngine.EngineName)
+        .AddChakraCore();
+
+      services.AddMvc(config =>
+      {
+        var policy = new AuthorizationPolicyBuilder()
+                              .RequireAuthenticatedUser()
+                              .Build();
+        config.Filters.Add(new AuthorizeFilter(policy));
+
+        config.CacheProfiles.Add("NoStore",
+              new Microsoft.AspNetCore.Mvc.CacheProfile()
+              {
+                NoStore = true
+              });
+      });
+      /*.AddJsonOptions(o =>
+          {
+              o.JsonSerializerOptions.PropertyNamingPolicy = null;
+              o.JsonSerializerOptions.DictionaryKeyPolicy = null;
+          });
 */
-            services.AddControllers().AddNewtonsoftJson();
+      services.AddControllers().AddNewtonsoftJson();
 
-            //https://docs.microsoft.com/en-us/aspnet/core/tutorials/web-api-help-pages-using-swagger?tabs=netcore-cli
-            // Register the Swagger generator, defining one or more Swagger documents
+      //https://docs.microsoft.com/en-us/aspnet/core/tutorials/web-api-help-pages-using-swagger?tabs=netcore-cli
+      // Register the Swagger generator, defining one or more Swagger documents
+
+      /*
+      services.AddSwaggerGen(c =>
+      {
+          c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo { Title = "My API", Version = "v1" });
+      });
+      */
+
+      services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
+      this.Start();
+    }
+
+
+    private CookieAuthenticationEvents get_sams_authentication_events()
+    {
+      //https://stackoverflow.com/questions/52175302/handling-expired-refresh-tokens-in-asp-net-core
+
+      var sams_endpoint_authorization = Configuration["sams:endpoint_authorization"];
+      var sams_endpoint_token = Configuration["sams:endpoint_token"];
+      var sams_endpoint_user_info = Configuration["sams:endpoint_user_info"];
+      var sams_endpoint_token_validation = Configuration["sams:token_validation"];
+      var sams_endpoint_user_info_sys = Configuration["sams:user_info_sys"];
+      var sams_client_id = Configuration["sams:client_id"];
+      var sams_client_secret = Configuration["sams:client_secret"];
+      var sams_callback_url = Configuration["sams:callback_url"];
+
+      var result = new CookieAuthenticationEvents
+      {
+        OnValidatePrincipal = context =>
+        {
+          //check to see if user is authenticated first
+          if (context.Principal.Identity.IsAuthenticated)
+          {
+
+
+            var expires_at = context.Request.Cookies["expires_at"];
+
+            var expires_at_time = DateTimeOffset.Parse(expires_at);
 
             /*
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo { Title = "My API", Version = "v1" });
-            });
-            */
-
-            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-
-            this.Start();
-        }
-
-        
-        private CookieAuthenticationEvents get_sams_authentication_events()
-        {
-            //https://stackoverflow.com/questions/52175302/handling-expired-refresh-tokens-in-asp-net-core
-
-            var sams_endpoint_authorization = Configuration["sams:endpoint_authorization"];
-            var sams_endpoint_token = Configuration["sams:endpoint_token"];
-            var sams_endpoint_user_info = Configuration["sams:endpoint_user_info"];
-            var sams_endpoint_token_validation = Configuration["sams:token_validation"];
-            var sams_endpoint_user_info_sys = Configuration["sams:user_info_sys"];
-            var sams_client_id = Configuration["sams:client_id"];
-            var sams_client_secret = Configuration["sams:client_secret"];
-            var sams_callback_url = Configuration["sams:callback_url"]; 
-
-            var result = new CookieAuthenticationEvents
-            {
-                OnValidatePrincipal = context =>
-                {
-                    //check to see if user is authenticated first
-                    if (context.Principal.Identity.IsAuthenticated)
-                    {
-
-                        
-                        var expires_at = context.Request.Cookies["expires_at"];
-
-                        var expires_at_time = DateTimeOffset.Parse(expires_at);
-                        
-/*
-                        var accessToken = context.Request.HttpContext.Session.GetString("access_token");
-                        var refreshToken = context.Request.HttpContext.Session.GetString("refresh_token");
-                        var exp = context.Request.HttpContext.Session.GetInt32("expires_in");
- */
+                                    var accessToken = context.Request.HttpContext.Session.GetString("access_token");
+                                    var refreshToken = context.Request.HttpContext.Session.GetString("refresh_token");
+                                    var exp = context.Request.HttpContext.Session.GetInt32("expires_in");
+             */
 
             /*
                         var tokens = context.Properties.GetTokens();
@@ -603,276 +612,296 @@ namespace mmria.server
                         var expires = DateTime.Parse(exp.Value);
                          */
 
-                        //context.Request.Cookies.["sid"].
-                       // var expires = DateTime.Parse(exp.ToString());
-                        //check to see if the token has expired
-                        if (expires_at_time.DateTime < DateTime.Now)
-                        {
-                            try 
-                            {
-                                var sid = context.Request.Cookies["sid"];
-
-                                string request_string = Program.config_couchdb_url + $"/{Program.db_prefix}session/{sid}";
-                                var curl = new cURL ("GET", null, request_string, null, Program.config_timer_user_name, Program.config_timer_value);
-                                string session_json = curl.execute();
-                                var session = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.session> (session_json);
-
-                                var userName = context.Principal.Identities.First(
-                                        u => u.IsAuthenticated && 
-                                        u.HasClaim(c => c.Type == ClaimTypes.Name)).FindFirst(ClaimTypes.Name).Value;
-
-
-                                if(!userName.Equals(session.user_id, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    context.RejectPrincipal();
-                                    return Task.CompletedTask;
-                                }
-
-                                var accessToken = session.data["access_token"];
-                                var refreshToken = session.data["refresh_token"];
-                                var exp = session.data["expires_at"];
-                                expires_at_time = DateTimeOffset.Parse(exp);
-                                
-                                // server-side check for expiration
-                                if (expires_at_time.DateTime < DateTime.Now)
-                                {
-                                    //token is expired, let's attempt to renew
-                                    var tokenEndpoint = sams_endpoint_token;
-                                    var tokenClient = new mmria.server.util.TokenClient(Configuration);
-
-                                    //var name = HttpContext.Session.GetString(SessionKeyName);
-                                    //var name = HttpContext.Session.GetString(SessionKeyName);
-
-                                    var tokenResponse = tokenClient.get_refresh_token(accessToken.ToString(), refreshToken.ToString()).Result;
-                                    //check for error while renewing - any error will trigger a new login.
-                                    if (tokenResponse.is_error)
-                                    {
-                                        //reject Principal
-                                        context.RejectPrincipal();
-                                        return Task.CompletedTask;
-                                    }
-                                    //set new token values
-                                    refreshToken = tokenResponse.refresh_token;
-                                    accessToken = tokenResponse.access_token;
-                                    var unix_time = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.expires_in);
-
-                                    session.data["access_token"] = accessToken;
-                                    session.data["refresh_token"] = refreshToken;
-                                    session.data["expires_at"] = unix_time.ToString();
-
-                                    context.Response.Cookies.Append("expires_at", unix_time.ToString(), new CookieOptions{ HttpOnly = true });
-
-
-                                    session.date_last_updated  = DateTime.UtcNow;
-
-
-                                    var Session_Message = new mmria.server.model.actor.Session_Message
-                                    (
-                                        session._id, //_id = 
-                                        session._rev, //_rev = 
-                                        session.date_created, //date_created = 
-                                        session.date_last_updated, //date_last_updated = 
-                                        session.date_expired, //date_expired = 
-
-                                        session.is_active, //is_active = 
-                                        session.user_id, //user_id = 
-                                        session.ip, //ip = 
-                                        session.session_event_id, // session_event_id = 
-                                        session.data
-                                    );
-
-                                    Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.Post_Session>()).Tell(Session_Message);
-    
-                                    //trigger context to renew cookie with new token values
-                                    context.ShouldRenew = true;
-                                    return Task.CompletedTask;
-                                }
-
-                            } 
-                            catch (Exception ex) 
-                            {
-                                // do nothing for now document doesn't exsist.
-                                System.Console.WriteLine ($"err caseController.Post\n{ex}");
-                            }
-                        }
-                    }
-                    return Task.CompletedTask;
-                }
-            };
-
-            return result;
-        }
-        
-        
-
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-        {
-
-
-            if (env.IsDevelopment())
+            //context.Request.Cookies.["sid"].
+            // var expires = DateTime.Parse(exp.ToString());
+            //check to see if the token has expired
+            if (expires_at_time.DateTime < DateTime.Now)
             {
-                app.UseDeveloperExceptionPage();
-            }
+              try
+              {
+                var sid = context.Request.Cookies["sid"];
 
-            app.Use
-            (
-                async (context, next) =>
+                string request_string = Program.config_couchdb_url + $"/{Program.db_prefix}session/{sid}";
+                var curl = new cURL("GET", null, request_string, null, Program.config_timer_user_name, Program.config_timer_value);
+                string session_json = curl.execute();
+                var session = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.session>(session_json);
+
+                var userName = context.Principal.Identities.First(
+                                u => u.IsAuthenticated &&
+                                u.HasClaim(c => c.Type == ClaimTypes.Name)).FindFirst(ClaimTypes.Name).Value;
+
+
+                if (!userName.Equals(session.user_id, StringComparison.OrdinalIgnoreCase))
                 {
-                    switch(context.Request.Method.ToLower())
-                    {
-
-                        case "get":
-                        case "put":
-                        case "post":
-                        case "head":                        
-                        case "delete":
-
-                            if
-                            (
-                                (context.Request.Headers.ContainsKey("Content-Length") && 
-                                context.Request.Headers["Content-Length"].Count > 1) ||
-                                (context.Request.Headers.ContainsKey("Transfer-Encoding") && 
-                                context.Request.Headers["Transfer-Encoding"].Count > 1)
-                            )
-                            {
-                                context.Response.StatusCode = 400;
-                                context.Response.Headers.Add("Connection", "close");
-                                //context.Abort();
-                                //context.RequestAborted.Session
-                            }
-                            else if
-                            (
-                                
-                                context.Request.Headers.ContainsKey("Content-Length") &&
-                                context.Request.Headers.ContainsKey("Transfer-Encoding")
-                            )
-                            {
-                                context.Response.StatusCode = 400;
-                                context.Response.Headers.Add("Connection", "close");
-                               // context.Abort();
-                            }
-                            else if
-                            (
-                                context.Request.Headers.ContainsKey("X-HTTP-METHOD") ||
-                                context.Request.Headers.ContainsKey("X-HTTP-Method-Override") ||
-                                context.Request.Headers.ContainsKey("X-METHOD-OVERRIDE")
-                            )
-                            {
-                                context.Response.Headers.Add("X-Frame-Options", "DENY");
-                                context.Response.Headers.Add("Content-Security-Policy",  
-                                "" +  
-                                "frame-ancestors  'none'"); 
-                                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
-                                context.Response.Headers.Add("Cache-Control","no-cache, no-store"); 
-                                context.Response.Headers.Add("X-XSS-Protection","1; mode=block"); 
-                                context.Response.Headers.Add("Connection", "close");
-                                context.Response.StatusCode = 400;
-                                //context.Abort();
-
-                            }
-                            else
-                            {
-                                context.Response.Headers.Add("X-Frame-Options", "DENY");
-                                context.Response.Headers.Add("Content-Security-Policy",  
-                                "" +  
-                                "frame-ancestors  'none'"); 
-                                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
-                                context.Response.Headers.Add("Cache-Control","no-cache, no-store"); 
-                                context.Response.Headers.Add("X-XSS-Protection","1; mode=block"); 
-
-                                await next();
-                            }
-
-                        break;
-                        default:
-                            context.Response.StatusCode = 400;
-                            context.Response.Headers.Add("Connection", "close");
-                            //context.Abort();
-                        break;
-                    }
+                  context.RejectPrincipal();
+                  return Task.CompletedTask;
                 }
-            );
+
+                var accessToken = session.data["access_token"];
+                var refreshToken = session.data["refresh_token"];
+                var exp = session.data["expires_at"];
+                expires_at_time = DateTimeOffset.Parse(exp);
+
+                // server-side check for expiration
+                if (expires_at_time.DateTime < DateTime.Now)
+                {
+                  //token is expired, let's attempt to renew
+                  var tokenEndpoint = sams_endpoint_token;
+                  var tokenClient = new mmria.server.util.TokenClient(Configuration);
+
+                  //var name = HttpContext.Session.GetString(SessionKeyName);
+                  //var name = HttpContext.Session.GetString(SessionKeyName);
+
+                  var tokenResponse = tokenClient.get_refresh_token(accessToken.ToString(), refreshToken.ToString()).Result;
+                  //check for error while renewing - any error will trigger a new login.
+                  if (tokenResponse.is_error)
+                  {
+                    //reject Principal
+                    context.RejectPrincipal();
+                    return Task.CompletedTask;
+                  }
+                  //set new token values
+                  refreshToken = tokenResponse.refresh_token;
+                  accessToken = tokenResponse.access_token;
+                  var unix_time = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.expires_in);
+
+                  session.data["access_token"] = accessToken;
+                  session.data["refresh_token"] = refreshToken;
+                  session.data["expires_at"] = unix_time.ToString();
+
+                  context.Response.Cookies.Append("expires_at", unix_time.ToString(), new CookieOptions { HttpOnly = true });
 
 
-            var use_sams = false;
-            
-            if(!string.IsNullOrWhiteSpace(Configuration["sams:is_enabled"]))
-            {
-                bool.TryParse(Configuration["sams:is_enabled"], out use_sams);
+                  session.date_last_updated = DateTime.UtcNow;
+
+
+                  var Session_Message = new mmria.server.model.actor.Session_Message
+                          (
+                              session._id, //_id = 
+                              session._rev, //_rev = 
+                              session.date_created, //date_created = 
+                              session.date_last_updated, //date_last_updated = 
+                              session.date_expired, //date_expired = 
+
+                              session.is_active, //is_active = 
+                              session.user_id, //user_id = 
+                              session.ip, //ip = 
+                              session.session_event_id, // session_event_id = 
+                              session.data
+                          );
+
+                  Program.actorSystem.ActorOf(Props.Create<mmria.server.model.actor.Post_Session>()).Tell(Session_Message);
+
+                  //trigger context to renew cookie with new token values
+                  context.ShouldRenew = true;
+                  return Task.CompletedTask;
+                }
+
+              }
+              catch (Exception ex)
+              {
+                // do nothing for now document doesn't exsist.
+                System.Console.WriteLine($"err caseController.Post\n{ex}");
+              }
             }
-/*
-            if(use_sams)
-            {
-                app.UseHttpsRedirection();
-            }
-            app.UseHttpsRedirection();
-            */
-            app.UseAuthentication();
-
-
-            //app.UseMvc();
-            //app.UseSession();
-            /*
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-            */
-            app.UseRouting();
-            app.UseAuthorization();
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}");
-            });
-
-            //app.UseHttpsRedirection();
-            app.UseDefaultFiles();
-            app.UseStaticFiles();
-
-            //http://localhost:5000/swagger/v1/swagger.json
-            // Enable middleware to serve generated Swagger as a JSON endpoint.
-            /*
-            app.UseSwagger();
-
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), specifying the Swagger JSON endpoint.
-            app.UseSwaggerUI(c =>
-            {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
-            });*/
-
+          }
+          return Task.CompletedTask;
         }
+      };
 
-        public void Start()
-		{
-            if(Program.is_schedule_enabled)
-            {
-                System.Threading.Tasks.Task.Run
-                (
-                    new Action (async () => 
-                    {
-                        await new mmria.server.util.c_db_setup(Program.actorSystem).Setup();
-                    }
-                    
-                ));
-            }
-			else
-            {
-                /*
-                System.Threading.Tasks.Task.Run
-                (
-                    new Action (async () => 
-                    {
-                        await new mmria.server.util.c_db_setup(Program.actorSystem).Install_Check();
-                    }
-                    
-                ));
-                 */
-            }
-
-            // ****   Quartz Timer - End
-		}
+      return result;
     }
+
+
+
+    public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+    {
+
+
+      if (env.IsDevelopment())
+      {
+        app.UseDeveloperExceptionPage();
+      }
+
+      app.Use
+      (
+          async (context, next) =>
+          {
+            switch (context.Request.Method.ToLower())
+            {
+
+              case "get":
+              case "put":
+              case "post":
+              case "head":
+              case "delete":
+
+                if
+                      (
+                          (context.Request.Headers.ContainsKey("Content-Length") &&
+                          context.Request.Headers["Content-Length"].Count > 1) ||
+                          (context.Request.Headers.ContainsKey("Transfer-Encoding") &&
+                          context.Request.Headers["Transfer-Encoding"].Count > 1)
+                      )
+                {
+                  context.Response.StatusCode = 400;
+                  context.Response.Headers.Add("Connection", "close");
+                  //context.Abort();
+                  //context.RequestAborted.Session
+                }
+                else if
+                      (
+
+                          context.Request.Headers.ContainsKey("Content-Length") &&
+                          context.Request.Headers.ContainsKey("Transfer-Encoding")
+                      )
+                {
+                  context.Response.StatusCode = 400;
+                  context.Response.Headers.Add("Connection", "close");
+                  // context.Abort();
+                }
+                else if
+                      (
+                          context.Request.Headers.ContainsKey("X-HTTP-METHOD") ||
+                          context.Request.Headers.ContainsKey("X-HTTP-Method-Override") ||
+                          context.Request.Headers.ContainsKey("X-METHOD-OVERRIDE")
+                      )
+                {
+                  context.Response.Headers.Add("X-Frame-Options", "DENY");
+                  context.Response.Headers.Add("Content-Security-Policy",
+                        "" +
+                        "frame-ancestors  'none'");
+                  context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+                  context.Response.Headers.Add("Cache-Control", "no-cache, no-store");
+                  context.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
+                  context.Response.Headers.Add("Connection", "close");
+                  context.Response.StatusCode = 400;
+                  //context.Abort();
+
+                }
+                else
+                {
+                  context.Response.Headers.Add("X-Frame-Options", "DENY");
+                  context.Response.Headers.Add("Content-Security-Policy",
+                        "" +
+                        "frame-ancestors  'none'");
+                  context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+                  context.Response.Headers.Add("Cache-Control", "no-cache, no-store");
+                  context.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
+
+                  await next();
+                }
+
+                break;
+              default:
+                context.Response.StatusCode = 400;
+                context.Response.Headers.Add("Connection", "close");
+                //context.Abort();
+                break;
+            }
+          }
+      );
+
+
+      var use_sams = false;
+
+      if (!string.IsNullOrWhiteSpace(Configuration["sams:is_enabled"]))
+      {
+        bool.TryParse(Configuration["sams:is_enabled"], out use_sams);
+      }
+      /*
+                  if(use_sams)
+                  {
+                      app.UseHttpsRedirection();
+                  }
+                  app.UseHttpsRedirection();
+                  */
+      app.UseAuthentication();
+
+
+      //app.UseMvc();
+      //app.UseSession();
+      /*
+      app.UseMvc(routes =>
+      {
+          routes.MapRoute(
+              name: "default",
+              template: "{controller=Home}/{action=Index}/{id?}");
+      });
+      */
+      app.UseRouting();
+      app.UseAuthorization();
+      app.UseEndpoints(endpoints =>
+      {
+        endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}");
+      });
+
+      //app.UseHttpsRedirection();
+      app.UseDefaultFiles();
+      // Initialise ReactJS.NET. Must be before static files.
+      app.UseReact(config =>
+      {
+        // If you want to use server-side rendering of React components,
+        // add all the necessary JavaScript files here. This includes
+        // your components as well as all of their dependencies.
+        // See http://reactjs.net/ for more information. Example:
+        config
+          .AddScript("~/reactjs/sharedmodules/*")
+          .AddScript("~/reactjs/ExportQueue/*");
+        //    .AddScript("~/js/Second.jsx");
+
+        // If you use an external build too (for example, Babel, Webpack,
+        // Browserify or Gulp), you can improve performance by disabling
+        // ReactJS.NET's version of Babel and loading the pre-transpiled
+        // scripts. Example:
+        //config
+        //    .SetLoadBabel(false)
+        //    .AddScriptWithoutTransform("~/Scripts/bundle.server.js");
+      });
+      app.UseStaticFiles();
+
+      //http://localhost:5000/swagger/v1/swagger.json
+      // Enable middleware to serve generated Swagger as a JSON endpoint.
+      /*
+      app.UseSwagger();
+
+      // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), specifying the Swagger JSON endpoint.
+      app.UseSwaggerUI(c =>
+      {
+          c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
+      });*/
+
+    }
+
+    public void Start()
+    {
+      if (Program.is_schedule_enabled)
+      {
+        System.Threading.Tasks.Task.Run
+        (
+            new Action(async () =>
+           {
+             await new mmria.server.util.c_db_setup(Program.actorSystem).Setup();
+           }
+
+        ));
+      }
+      else
+      {
+        /*
+        System.Threading.Tasks.Task.Run
+        (
+            new Action (async () => 
+            {
+                await new mmria.server.util.c_db_setup(Program.actorSystem).Install_Check();
+            }
+
+        ));
+         */
+      }
+
+      // ****   Quartz Timer - End
+    }
+  }
 
 }

--- a/source-code/mmria/mmria-server/Views/Shared/_LayoutBase.cshtml
+++ b/source-code/mmria/mmria-server/Views/Shared/_LayoutBase.cshtml
@@ -49,11 +49,14 @@
     
   @await Html.PartialAsync("_Footer")
   @await Html.PartialAsync("_Spinner")
-
+  
+  <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/16.13.0/umd/react.development.js"></script>
+  <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.13.0/umd/react-dom.development.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/remarkable/1.7.1/remarkable.min.js"></script>
   <script src="/scripts/mmria-custom.js"></script>
 
-  @RenderSection("Scripts", false)
 
-  
+  @RenderSection("Scripts", false)
+  @Html.ReactInitJavaScript()
 </body>
 </html>

--- a/source-code/mmria/mmria-server/Views/_ViewImports.cshtml
+++ b/source-code/mmria/mmria-server/Views/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@using React.AspNet

--- a/source-code/mmria/mmria-server/Views/export_queue/Index.cshtml
+++ b/source-code/mmria/mmria-server/Views/export_queue/Index.cshtml
@@ -22,21 +22,18 @@
   <script src="../scripts/export-queue/export_queue_renderer.js" type="text/javascript"></script>
   <script src="../scripts/url_monitor.js" type="text/javascript"></script>
   <script src="../scripts/mmria.js" type="text/javascript"></script>
-  <script src="../scripts/export-queue/index.js" type="text/javascript"></script>
+  
 
 }
 
 <h1 class="h2 mb-4">Export Data</h1>
 <div id='form_content_id'></div>
-<br/>
----------------------REACT VERSION---------------------
-<br/>
 
 @section Scripts {
-  @* <script src="~/js/test.jsx"></script> *@
   <script src="@Url.Content("~/reactjs/sharedmodules/Spinner.jsx")"></script>
   <script src="@Url.Content("~/reactjs/ExportQueue/SelectOptions.jsx")"></script>
   <script src="@Url.Content("~/reactjs/ExportQueue/ExportQueue.jsx")"></script>
+  <script src="../scripts/export-queue/index.js" type="text/javascript"></script>
 }
 
-@Html.React("ExportQueue", new {})
+@* @Html.React("ExportQueue", new {}) *@

--- a/source-code/mmria/mmria-server/Views/export_queue/Index.cshtml
+++ b/source-code/mmria/mmria-server/Views/export_queue/Index.cshtml
@@ -28,3 +28,15 @@
 
 <h1 class="h2 mb-4">Export Data</h1>
 <div id='form_content_id'></div>
+<br/>
+---------------------REACT VERSION---------------------
+<br/>
+
+@section Scripts {
+  @* <script src="~/js/test.jsx"></script> *@
+  <script src="@Url.Content("~/reactjs/sharedmodules/Spinner.jsx")"></script>
+  <script src="@Url.Content("~/reactjs/ExportQueue/SelectOptions.jsx")"></script>
+  <script src="@Url.Content("~/reactjs/ExportQueue/ExportQueue.jsx")"></script>
+}
+
+@Html.React("ExportQueue", new {})

--- a/source-code/mmria/mmria-server/mmria-server.csproj
+++ b/source-code/mmria/mmria-server/mmria-server.csproj
@@ -2,55 +2,42 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <UserSecretsId>mmria-secret-id</UserSecretsId>
-	<OutputType>Exe</OutputType>
-   <DefaultItemExcludes>$(DefaultItemExcludes);MMRIA_Window_Service.cs;Program.service.cs;a\**\*.pattern</DefaultItemExcludes>
+    <OutputType>Exe</OutputType>
+    <DefaultItemExcludes>$(DefaultItemExcludes);MMRIA_Window_Service.cs;Program.service.cs;a\**\*.pattern</DefaultItemExcludes>
   </PropertyGroup>
-
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-    <Folder Include="util\" />
-   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.6.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
-
-
-    <PackageReference Include="Akka" Version="1.3.17" />
-    <PackageReference Include="Akka.Quartz.Actor" Version="1.3.3" />
-    <PackageReference Include="Autofac" Version="4.6.2" />
-    <!--PackageReference Include="Microsoft.AspNetCore.Aapp" Version="2.0.9" /-->
-
-  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-  <!--PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.0" /-->
-  
-
-  <!--PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" /-->
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.1" />
-
-    <PackageReference Include="Quartz" Version="3.0.7" />
-    <PackageReference Include="SharpZipLib" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-    <!--PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" /-->
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
-    
-    <PackageReference Include="NJsonSchema" Version="10.0.27" />
-    <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="10.0.27" />
-
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0" />
-
-
-
+    <Folder Include="wwwroot\"/>
+    <Folder Include="util\"/>
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
+    <PackageReference Include="Serilog" Version="2.6.0"/>
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1"/>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2"/>
+    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0"/>
+    <PackageReference Include="Akka" Version="1.3.17"/>
+    <PackageReference Include="Akka.Quartz.Actor" Version="1.3.3"/>
+    <PackageReference Include="Autofac" Version="4.6.2"/>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1"/>
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.1"/>
+    <PackageReference Include="Quartz" Version="3.0.7"/>
+    <PackageReference Include="SharpZipLib" Version="1.1.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="2.0.1"/>
+    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0"/>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1"/>
+    <PackageReference Include="NJsonSchema" Version="10.0.27"/>
+    <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="10.0.27"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0"/>
+    <PackageReference Include="React.AspNet" Version="5.2.6"/>
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.5.6"/>
+    <PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.3.0"/>
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.5.6"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\mmria.common\mmria.common.csproj" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\mmria.common\mmria.common.csproj"/>
   </ItemGroup>
 </Project>

--- a/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/exportqueue.jsx
+++ b/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/exportqueue.jsx
@@ -1,0 +1,477 @@
+class ResponseTableRow extends React.Component {
+  escapeText(text) {
+    return escape(text).replace(/%20/g, ' ').replace(/%3A/g, '-');
+  }
+  render() {
+    const { rowData, selectRow, checked } = this.props;
+    return (
+      <tr class="tr font-weight-normal">
+        <td class="td" data-type="date_created" width="38" align="center">
+          <input
+            id={escape(rowData.id)}
+            type="checkbox"
+            value={escape(rowData.id)}
+            type="checkbox"
+            onClick={selectRow}
+            checked={checked}
+          />
+          <label for="" class="sr-only">
+            {escape(rowData.id)}
+          </label>
+        </td>
+        <td class="td" data-type="date_last_updated">
+          {this.escapeText(rowData.value.date_last_updated)} <br />{' '}
+          {escape(rowData.value.last_updated_by)}
+        </td>
+        <td class="td" data-type="jurisdiction_id">
+          {this.escapeText(rowData.value.last_name)},{' '}
+          {this.escapeText(rowData.value.first_name)}{' '}
+          {this.escapeText(rowData.value.middle_name)} [
+          {escape(rowData.value.jurisdiction_id)}]
+        </td>
+        <td class="td" data-type="record_id">
+          {this.escapeText(rowData.value.record_id)}
+        </td>
+        <td class="td" data-type="date_of_death">
+          {rowData.value.date_of_death_year != null
+            ? escape(rowData.value.date_of_death_year)
+            : ''}
+          -
+          {rowData.value.date_of_death_month != null
+            ? escape(rowData.value.date_of_death_month)
+            : ''}
+        </td>
+        <td class="td" data-type="committee_review_date">
+          {rowData.value.committee_review_date != null
+            ? escape(rowData.value.committee_review_date)
+            : 'N/A'}
+        </td>
+        <td class="td" data-type="agency_case_id">
+          {this.escapeText(rowData.value.agency_case_id)}
+        </td>
+        <td class="td" data-type="date_last_updated">
+          {this.escapeText(rowData.value.date_last_updated)}
+          <br />
+          {this.escapeText(rowData.value.created_by)}
+        </td>
+      </tr>
+    );
+  }
+  // let item = case_view_response.rows[i];
+  // let value_list = item.value;
+
+  // selected_dictionary[item.id] = value_list;
+
+  // let checked = '';
+  // let index = answer_summary.case_set.indexOf(item.id);
+
+  // if (index > -1) {
+  //   checked = 'checked=true';
+  // }
+
+  // // Items generated after user applies filters
+  // html.push(`
+
+  // `);
+  // html.push(`<li class="foo"><input value=${escape(item.id)} type="checkbox" onclick="result_checkbox_click(this)" ${checked} /> ${escape(value_list.jurisdiction_id)} ${escape(value_list.last_name)},${escape(value_list.first_name)} ${escape(value_list.date_of_death_year)}/${escape(value_list.date_of_death_month)} ${escape(value_list.date_last_updated)} ${escape(value_list.last_updated_by)} agency_id:${escape(value_list.agency_case_id)} rc_id:${escape(value_list.record_id)}</li>`);
+}
+
+class ExportTable extends React.Component {
+  render() {
+    const { title, children } = this.props;
+    return (
+      <table className="table rounded-0 m-0">
+        <thead className="thead">
+          <tr className="tr bg-tertiary">
+            <th className="th" colSpan="14" scope="colgroup">
+              <span className="row no-gutters justify-content-between">
+                <span>{title}</span>
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <thead className="thead">
+          <tr className="tr">
+            <th className="th" width="38" scope="col"></th>
+            <th className="th" scope="col">
+              Date last updated <br />
+              Last updated by
+            </th>
+            <th className="th" scope="col">
+              Name [Jurisdiction ID]
+            </th>
+            <th className="th" scope="col">
+              Record ID
+            </th>
+            <th className="th" scope="col">
+              Date of death
+            </th>
+            <th className="th" scope="col">
+              Committee review date
+            </th>
+            <th className="th" scope="col">
+              Agency case ID
+            </th>
+            <th className="th" scope="col">
+              Date created
+              <br />
+              Created by
+            </th>
+          </tr>
+        </thead>
+        <tbody id="search_result_list" className="tbody">
+          {children}
+        </tbody>
+      </table>
+    );
+  }
+}
+
+class Paginations extends React.Component {
+  handleClick(page) {
+    //g_ui.case_view_request.page = page;
+    this.props.getCaseSet({ page });
+  }
+  render() {
+    const { totalRows, take, page } = this.props;
+    const BUTTONS = [];
+    for (
+      let currentPage = 1;
+      (currentPage - 1) * take < totalRows;
+      currentPage++
+    ) {
+      BUTTONS.push(
+        <button
+          type="button"
+          key={`button-${currentPage}`}
+          className="table-btn-link btn btn-link"
+          alt="select page 1"
+          onClick={() => handleClick(currentPage)}
+        >
+          {currentPage}
+        </button>
+      );
+    }
+    return (
+      <div className="table-pagination row align-items-center no-gutters pt-1 pb-1 pl-2 pr-2">
+        <div className="col">
+          <div className="row no-gutters">
+            <p className="mb-0">
+              Total Records: <strong>{totalRows}</strong>
+            </p>
+            <p className="mb-0 ml-2 mr-2">|</p>
+            <p className="mb-0">
+              Viewing Page(s): <strong>{page}</strong> of{' '}
+              <strong>{BUTTONS.length}</strong>
+            </p>
+          </div>
+        </div>
+        <div className="col row no-gutters align-items-center justify-content-end">
+          <p className="mb-0">Select by page:</p>
+          {BUTTONS}
+        </div>
+      </div>
+    );
+  }
+}
+
+function getQueryString({ page, take, sort, searchText, descending }) {
+  const result = [];
+  result.push('?skip=' + (page - 1) * take);
+  result.push('take=' + take);
+  result.push('sort=' + sort);
+  if (searchText) {
+    result.push(
+      'search_key="' +
+        searchText.replace(/"/g, '\\"').replace(/\n/g, '\\n') +
+        '"'
+    );
+  }
+  result.push('descending=' + descending);
+  return result.join('&');
+}
+
+class ExportQueue extends React.Component {
+  state = {
+    filterSortBy: [
+      { value: 'first_name', text: 'First name' },
+      { value: 'middle_name', text: 'Middle name' },
+      { value: 'last_name', text: 'Last name' },
+      { value: 'date_of_death_year', text: 'Date of death year' },
+      { value: 'date_of_death_month', text: 'Date of death month' },
+      { value: 'date_created', text: 'Date created' },
+      { value: 'created_by', text: 'Created by' },
+      {
+        value: 'date_last_updated',
+        selected: true,
+        text: 'Date last updated',
+      },
+      { value: 'last_updated_by', text: 'Last updated by' },
+      { value: 'record_id', text: 'Record id' },
+      { value: 'agency_case_id', text: 'Agency case id' },
+      { value: 'date_of_committee_review', text: 'Date of committee review' },
+      { value: 'jurisdiction_id', text: 'Jurisdiction id' },
+    ],
+    filterRecordsPerPage: [
+      { text: '25' },
+      { text: '50' },
+      { text: '100', selected: true },
+      { text: '250' },
+      { text: '500' },
+    ],
+    showCustomCaseFilter: false,
+    caseViewResponse: [],
+    caseViewResponseTotalRows: 0,
+    selectedRows: {},
+    searchText: '',
+    page: 1,
+    skip: 0,
+    take: 100,
+    sort: 'date_last_updated',
+    descending: true,
+  };
+
+  caseFilterTypeClick = (e) => {
+    const p_value = e.target.value;
+    answer_summary.case_filter_type = p_value.toLowerCase();
+
+    // var custom_case_filter = document.getElementById("custom_case_filter");
+    // if(p_value.value.toLowerCase() == "custom")
+    // {
+    //   custom_case_filter.style.display = "block";
+    // }
+    // else
+    // {
+    //   custom_case_filter.style.display = "none";
+    // }
+    this.setState({
+      showCustomCaseFilter: !!(p_value.toLowerCase() === 'custom'),
+    });
+
+    //renderSummarySection(p_value);
+  };
+
+  filterSearchTextChange = (e) => {
+    const { value } = e.target;
+    this.setState({ searchText: value });
+    //g_case_view_request.search_key = value;
+  };
+
+  getCaseSet = ({ page }) => {
+    const { protocol, host } = location;
+    let caseViewUrl = `${protocol}//${host}/api/case_view`;
+    if (page) {
+      this.setState({ page });
+      caseViewUrl += `${getQueryString({ ...this.state, page })}`;
+    } else {
+      caseViewUrl += `${getQueryString(this.state)}`;
+    }
+
+    fetch(caseViewUrl)
+      .then((response) => response.json())
+      .then((resp) => {
+        // g_case_view_request.total_rows = resp.total_rows;
+        // g_case_view_request.respone_rows = resp.rows;
+        this.setState({
+          loading: false,
+          caseViewResponse: resp.rows,
+          caseViewResponseTotalRows: resp.total_rows,
+        });
+
+        // el = document.getElementById('case_result_pagination');
+        // html = [];
+        // render_pagination(html, g_case_view_request);
+        // el.innerHTML = html.join('');
+      });
+  };
+  setPage = (page) => {
+    this.setState({ page });
+  };
+  applyFilterButtonClick = () => {
+    this.setState({ loading: true });
+    const searchText = document.getElementById('filter_search_text').value;
+    const sort = document.getElementById('filter_sort_by').value;
+    const take = document.getElementById('filter_records_perPage').value;
+    const descending = document.getElementById('filter_decending').value;
+    this.setState({
+      take,
+      searchText,
+      sort,
+      descending,
+      loading: true,
+    });
+
+    this.getCaseSet({});
+  };
+
+  result_checkbox_click() {}
+  selectRow = (e) => {
+    const rowId = e.target.value;
+    const selectedRowId = this.state.selectedRows[rowId];
+    // by default it will be selected if it is not already in the selectedRows memo
+    const selected = selectedRowId !== undefined ? !selectedRowId : false;
+    // create a new memo
+    const newSelectedRows = { ...this.state.selectedRows, [rowId]: selected };
+    this.setState({
+      selectedRows: newSelectedRows,
+    });
+  };
+  render() {
+    const listStyle = {
+      overflow: 'hidden',
+      overflowY: 'auto',
+      height: '360px',
+      border: '1px solid #ced4da',
+    };
+    const INCLUDED_CASE_ROWS = [];
+    const CASE_ROWS = this.state.caseViewResponse.map((rowData) => {
+      const selectedIdValue = this.state.selectedRows[rowData.id];
+      const checked = selectedIdValue === undefined ? true : selectedIdValue;
+      if (selectedIdValue === undefined || selectedIdValue === true) {
+        INCLUDED_CASE_ROWS.push(
+          <ResponseTableRow
+            key={'inc' + rowData.id}
+            {...{ rowData, checked: true, selectRow: () => {} }}
+          />
+        );
+      }
+      const { selectRow } = this;
+      return (
+        <ResponseTableRow
+          key={rowData.id}
+          {...{ rowData, checked, selectRow }}
+        />
+      );
+    });
+    return (
+      <li className="mb-4">
+        <p className="mb-3">
+          Please select which cases you want to include in the export?
+        </p>
+        <label
+          htmlFor="case_filter_type_all"
+          className="font-weight-normal mr-2"
+        >
+          <input
+            id="case_filter_type_all"
+            type="radio"
+            name="case_filter_type"
+            value="all"
+            checked={this.state.showCustomCaseFilter === false}
+            onChange={this.caseFilterTypeClick}
+          />{' '}
+          All
+        </label>
+        <label
+          htmlFor="case_filter_type_custom2"
+          className="font-weight-normal"
+        >
+          <input
+            id="case_filter_type_custom"
+            type="radio"
+            name="case_filter_type_custom"
+            value="custom"
+            checked={this.state.showCustomCaseFilter === true}
+            onChange={this.caseFilterTypeClick}
+          />{' '}
+          Custom
+        </label>
+        <ul
+          className="font-weight-bold list-unstyled mt-3"
+          style={{
+            display: this.state.showCustomCaseFilter ? 'block' : 'none',
+          }}
+        >
+          <li className="mb-4">
+            <div className="form-inline mb-2">
+              <label
+                htmlFor="filter_search_text"
+                className="font-weight-normal mr-2"
+              >
+                Search for:
+              </label>
+              <input
+                type="text"
+                className="form-control mr-2"
+                id="filter_search_text"
+                value={this.state.searchText}
+                onChange={this.filterSearchTextChange}
+              />
+              <button
+                type="button"
+                className="btn btn-secondary"
+                alt="search"
+                onClick={this.applyFilterButtonClick}
+              >
+                Apply Filters
+              </button>
+              <Spinner active={this.state.loading} />
+            </div>
+
+            <div className="form-inline mb-2">
+              <label
+                htmlFor="filter_sort_by"
+                className="font-weight-normal mr-2"
+              >
+                Sort by:
+              </label>
+              <SelectOptions
+                id={'filter_sort_by'}
+                options={this.state.filterSortBy}
+              />
+            </div>
+
+            <div className="form-inline mb-2">
+              <label
+                htmlFor="filter_records_perPage"
+                className="font-weight-normal mr-2"
+              >
+                Records per page:
+              </label>
+              <SelectOptions
+                id={'filter_records_perPage'}
+                options={this.state.filterRecordsPerPage}
+              />
+            </div>
+
+            <div className="form-inline mb-2">
+              <label
+                htmlFor="filter_decending"
+                className="font-weight-normal mr-2"
+              >
+                Descending order:
+              </label>
+              <input
+                id="filter_decending"
+                type="checkbox"
+                defaultChecked="true"
+              />
+            </div>
+          </li>
+          {!!this.state.caseViewResponse.length && !this.state.loading && (
+            <React.Fragment>
+              <li className="mb-3" style={listStyle}>
+                <Paginations
+                  {...{
+                    totalRows: this.state.caseViewResponseTotalRows,
+                    take: this.state.take,
+                    page: this.state.page,
+                    getCaseSet: this.getCaseSet,
+                  }}
+                />
+                <ExportTable title={'Filtered Cases'}>{CASE_ROWS}</ExportTable>
+              </li>
+              <li className="" style={listStyle}>
+                <ExportTable
+                  title={`Cases to be included in export (${INCLUDED_CASE_ROWS.length}):`}
+                >
+                  {INCLUDED_CASE_ROWS}
+                </ExportTable>
+              </li>
+            </React.Fragment>
+          )}
+        </ul>
+      </li>
+    );
+  }
+}

--- a/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/exportqueue.jsx
+++ b/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/exportqueue.jsx
@@ -5,34 +5,34 @@ class ResponseTableRow extends React.Component {
   render() {
     const { rowData, selectRow, checked, rowId } = this.props;
     return (
-      <tr class="tr font-weight-normal">
-        <td class="td" data-type="date_created" width="38" align="center">
+      <tr className="tr font-weight-normal">
+        <td className="td" data-type="date_created" width="38" align="center">
           <input
             id={escape(rowId)}
             type="checkbox"
             value={escape(rowId)}
             type="checkbox"
-            onClick={selectRow}
+            onChange={selectRow}
             checked={checked}
           />
-          <label for="" class="sr-only">
+          <label htmlFor="" className="sr-only">
             {escape(rowId)}
           </label>
         </td>
-        <td class="td" data-type="date_last_updated">
+        <td className="td" data-type="date_last_updated">
           {this.escapeText(rowData.date_last_updated)} <br />{' '}
           {escape(rowData.last_updated_by)}
         </td>
-        <td class="td" data-type="jurisdiction_id">
+        <td className="td" data-type="jurisdiction_id">
           {this.escapeText(rowData.last_name)},{' '}
           {this.escapeText(rowData.first_name)}{' '}
           {this.escapeText(rowData.middle_name)} [
           {escape(rowData.jurisdiction_id)}]
         </td>
-        <td class="td" data-type="record_id">
+        <td className="td" data-type="record_id">
           {this.escapeText(rowData.record_id)}
         </td>
-        <td class="td" data-type="date_of_death">
+        <td className="td" data-type="date_of_death">
           {rowData.date_of_death_year != null
             ? escape(rowData.date_of_death_year)
             : ''}
@@ -41,15 +41,15 @@ class ResponseTableRow extends React.Component {
             ? escape(rowData.date_of_death_month)
             : ''}
         </td>
-        <td class="td" data-type="committee_review_date">
+        <td className="td" data-type="committee_review_date">
           {rowData.committee_review_date != null
             ? escape(rowData.committee_review_date)
             : 'N/A'}
         </td>
-        <td class="td" data-type="agency_case_id">
+        <td className="td" data-type="agency_case_id">
           {this.escapeText(rowData.agency_case_id)}
         </td>
-        <td class="td" data-type="date_last_updated">
+        <td className="td" data-type="date_last_updated">
           {this.escapeText(rowData.date_last_updated)}
           <br />
           {this.escapeText(rowData.created_by)}
@@ -73,7 +73,7 @@ class ResponseTableRow extends React.Component {
   // html.push(`
 
   // `);
-  // html.push(`<li class="foo"><input value=${escape(item.id)} type="checkbox" onclick="result_checkbox_click(this)" ${checked} /> ${escape(value_list.jurisdiction_id)} ${escape(value_list.last_name)},${escape(value_list.first_name)} ${escape(value_list.date_of_death_year)}/${escape(value_list.date_of_death_month)} ${escape(value_list.date_last_updated)} ${escape(value_list.last_updated_by)} agency_id:${escape(value_list.agency_case_id)} rc_id:${escape(value_list.record_id)}</li>`);
+  // html.push(`<li className="foo"><input value=${escape(item.id)} type="checkbox" onclick="result_checkbox_click(this)" ${checked} /> ${escape(value_list.jurisdiction_id)} ${escape(value_list.last_name)},${escape(value_list.first_name)} ${escape(value_list.date_of_death_year)}/${escape(value_list.date_of_death_month)} ${escape(value_list.date_last_updated)} ${escape(value_list.last_updated_by)} agency_id:${escape(value_list.agency_case_id)} rc_id:${escape(value_list.record_id)}</li>`);
 }
 
 class ExportTable extends React.Component {
@@ -237,27 +237,14 @@ class ExportQueue extends React.Component {
   caseFilterTypeClick = (e) => {
     const p_value = e.target.value;
     answer_summary.case_filter_type = p_value.toLowerCase();
-
-    // var custom_case_filter = document.getElementById("custom_case_filter");
-    // if(p_value.value.toLowerCase() == "custom")
-    // {
-    //   custom_case_filter.style.display = "block";
-    // }
-    // else
-    // {
-    //   custom_case_filter.style.display = "none";
-    // }
     this.setState({
       showCustomCaseFilter: !!(p_value.toLowerCase() === 'custom'),
     });
-
-    //renderSummarySection(p_value);
   };
 
   filterSearchTextChange = (e) => {
     const { value } = e.target;
     this.setState({ searchText: value });
-    //g_case_view_request.search_key = value;
   };
 
   getCaseSet = ({ page }) => {
@@ -273,8 +260,6 @@ class ExportQueue extends React.Component {
     fetch(caseViewUrl)
       .then((response) => response.json())
       .then((resp) => {
-        // g_case_view_request.total_rows = resp.total_rows;
-        // g_case_view_request.respone_rows = resp.rows;
         this.setState({
           loading: false,
           caseViewResponse: resp.rows,
@@ -286,15 +271,9 @@ class ExportQueue extends React.Component {
           let value_list = item.value;
           selected_dictionary[item.id] = value_list;
         }
-        // el = document.getElementById('case_result_pagination');
-        // html = [];
-        // render_pagination(html, g_case_view_request);
-        // el.innerHTML = html.join('');
       });
   };
-  setPage = (page) => {
-    this.setState({ page });
-  };
+
   applyFilterButtonClick = () => {
     this.setState({ loading: true });
     const searchText = document.getElementById('filter_search_text').value;
@@ -327,7 +306,7 @@ class ExportQueue extends React.Component {
     }
     const selectedRowId = this.state.selectedRows[rowId];
     // by default it will be selected if it is not already in the selectedRows memo
-    const selected = selectedRowId !== undefined ? !selectedRowId : false;
+    const selected = !selectedRowId;
     // create a new memo
     const newSelectedRows = { ...this.state.selectedRows, [rowId]: selected };
     this.setState({

--- a/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/exportqueue.jsx
+++ b/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/exportqueue.jsx
@@ -3,56 +3,56 @@ class ResponseTableRow extends React.Component {
     return escape(text).replace(/%20/g, ' ').replace(/%3A/g, '-');
   }
   render() {
-    const { rowData, selectRow, checked } = this.props;
+    const { rowData, selectRow, checked, rowId } = this.props;
     return (
       <tr class="tr font-weight-normal">
         <td class="td" data-type="date_created" width="38" align="center">
           <input
-            id={escape(rowData.id)}
+            id={escape(rowId)}
             type="checkbox"
-            value={escape(rowData.id)}
+            value={escape(rowId)}
             type="checkbox"
             onClick={selectRow}
             checked={checked}
           />
           <label for="" class="sr-only">
-            {escape(rowData.id)}
+            {escape(rowId)}
           </label>
         </td>
         <td class="td" data-type="date_last_updated">
-          {this.escapeText(rowData.value.date_last_updated)} <br />{' '}
-          {escape(rowData.value.last_updated_by)}
+          {this.escapeText(rowData.date_last_updated)} <br />{' '}
+          {escape(rowData.last_updated_by)}
         </td>
         <td class="td" data-type="jurisdiction_id">
-          {this.escapeText(rowData.value.last_name)},{' '}
-          {this.escapeText(rowData.value.first_name)}{' '}
-          {this.escapeText(rowData.value.middle_name)} [
-          {escape(rowData.value.jurisdiction_id)}]
+          {this.escapeText(rowData.last_name)},{' '}
+          {this.escapeText(rowData.first_name)}{' '}
+          {this.escapeText(rowData.middle_name)} [
+          {escape(rowData.jurisdiction_id)}]
         </td>
         <td class="td" data-type="record_id">
-          {this.escapeText(rowData.value.record_id)}
+          {this.escapeText(rowData.record_id)}
         </td>
         <td class="td" data-type="date_of_death">
-          {rowData.value.date_of_death_year != null
-            ? escape(rowData.value.date_of_death_year)
+          {rowData.date_of_death_year != null
+            ? escape(rowData.date_of_death_year)
             : ''}
           -
-          {rowData.value.date_of_death_month != null
-            ? escape(rowData.value.date_of_death_month)
+          {rowData.date_of_death_month != null
+            ? escape(rowData.date_of_death_month)
             : ''}
         </td>
         <td class="td" data-type="committee_review_date">
-          {rowData.value.committee_review_date != null
-            ? escape(rowData.value.committee_review_date)
+          {rowData.committee_review_date != null
+            ? escape(rowData.committee_review_date)
             : 'N/A'}
         </td>
         <td class="td" data-type="agency_case_id">
-          {this.escapeText(rowData.value.agency_case_id)}
+          {this.escapeText(rowData.agency_case_id)}
         </td>
         <td class="td" data-type="date_last_updated">
-          {this.escapeText(rowData.value.date_last_updated)}
+          {this.escapeText(rowData.date_last_updated)}
           <br />
-          {this.escapeText(rowData.value.created_by)}
+          {this.escapeText(rowData.created_by)}
         </td>
       </tr>
     );
@@ -192,44 +192,47 @@ function getQueryString({ page, take, sort, searchText, descending }) {
 }
 
 class ExportQueue extends React.Component {
-  state = {
-    filterSortBy: [
-      { value: 'first_name', text: 'First name' },
-      { value: 'middle_name', text: 'Middle name' },
-      { value: 'last_name', text: 'Last name' },
-      { value: 'date_of_death_year', text: 'Date of death year' },
-      { value: 'date_of_death_month', text: 'Date of death month' },
-      { value: 'date_created', text: 'Date created' },
-      { value: 'created_by', text: 'Created by' },
-      {
-        value: 'date_last_updated',
-        selected: true,
-        text: 'Date last updated',
-      },
-      { value: 'last_updated_by', text: 'Last updated by' },
-      { value: 'record_id', text: 'Record id' },
-      { value: 'agency_case_id', text: 'Agency case id' },
-      { value: 'date_of_committee_review', text: 'Date of committee review' },
-      { value: 'jurisdiction_id', text: 'Jurisdiction id' },
-    ],
-    filterRecordsPerPage: [
-      { text: '25' },
-      { text: '50' },
-      { text: '100', selected: true },
-      { text: '250' },
-      { text: '500' },
-    ],
-    showCustomCaseFilter: false,
-    caseViewResponse: [],
-    caseViewResponseTotalRows: 0,
-    selectedRows: {},
-    searchText: '',
-    page: 1,
-    skip: 0,
-    take: 100,
-    sort: 'date_last_updated',
-    descending: true,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      filterSortBy: [
+        { value: 'first_name', text: 'First name' },
+        { value: 'middle_name', text: 'Middle name' },
+        { value: 'last_name', text: 'Last name' },
+        { value: 'date_of_death_year', text: 'Date of death year' },
+        { value: 'date_of_death_month', text: 'Date of death month' },
+        { value: 'date_created', text: 'Date created' },
+        { value: 'created_by', text: 'Created by' },
+        {
+          value: 'date_last_updated',
+          selected: true,
+          text: 'Date last updated',
+        },
+        { value: 'last_updated_by', text: 'Last updated by' },
+        { value: 'record_id', text: 'Record id' },
+        { value: 'agency_case_id', text: 'Agency case id' },
+        { value: 'date_of_committee_review', text: 'Date of committee review' },
+        { value: 'jurisdiction_id', text: 'Jurisdiction id' },
+      ],
+      filterRecordsPerPage: [
+        { text: '25' },
+        { text: '50' },
+        { text: '100', selected: true },
+        { text: '250' },
+        { text: '500' },
+      ],
+      showCustomCaseFilter: this.props.showCustomCaseFilter,
+      caseViewResponse: [],
+      caseViewResponseTotalRows: 0,
+      selectedRows: this.props.caseSet,
+      searchText: '',
+      page: 1,
+      skip: 0,
+      take: 100,
+      sort: 'date_last_updated',
+      descending: true,
+    };
+  }
 
   caseFilterTypeClick = (e) => {
     const p_value = e.target.value;
@@ -277,7 +280,12 @@ class ExportQueue extends React.Component {
           caseViewResponse: resp.rows,
           caseViewResponseTotalRows: resp.total_rows,
         });
-
+        for (let i = 0; i < resp.rows.length; i++) {
+          // cache the response
+          let item = resp.rows[i];
+          let value_list = item.value;
+          selected_dictionary[item.id] = value_list;
+        }
         // el = document.getElementById('case_result_pagination');
         // html = [];
         // render_pagination(html, g_case_view_request);
@@ -307,6 +315,16 @@ class ExportQueue extends React.Component {
   result_checkbox_click() {}
   selectRow = (e) => {
     const rowId = e.target.value;
+    if (e.target.checked) {
+      if (answer_summary.case_set.indexOf(rowId) < 0) {
+        answer_summary.case_set.push(rowId);
+      }
+    } else {
+      let index = answer_summary.case_set.indexOf(rowId);
+      if (index > -1) {
+        answer_summary.case_set.splice(index, 1);
+      }
+    }
     const selectedRowId = this.state.selectedRows[rowId];
     // by default it will be selected if it is not already in the selectedRows memo
     const selected = selectedRowId !== undefined ? !selectedRowId : false;
@@ -324,27 +342,36 @@ class ExportQueue extends React.Component {
       border: '1px solid #ced4da',
     };
     const INCLUDED_CASE_ROWS = [];
-    const CASE_ROWS = this.state.caseViewResponse.map((rowData) => {
-      const selectedIdValue = this.state.selectedRows[rowData.id];
-      const checked = selectedIdValue === undefined ? true : selectedIdValue;
-      if (selectedIdValue === undefined || selectedIdValue === true) {
-        INCLUDED_CASE_ROWS.push(
-          <ResponseTableRow
-            key={'inc' + rowData.id}
-            {...{ rowData, checked: true, selectRow: () => {} }}
-          />
-        );
-      }
+    const CASE_ROWS = this.state.caseViewResponse.map((respData) => {
+      const selectedIdValue = this.state.selectedRows[respData.id];
+      const checked = !!selectedIdValue;
       const { selectRow } = this;
       return (
         <ResponseTableRow
-          key={rowData.id}
-          {...{ rowData, checked, selectRow }}
+          key={respData.id}
+          {...{
+            rowData: respData.value,
+            checked,
+            selectRow,
+            rowId: respData.id,
+          }}
         />
       );
     });
+    Object.keys(this.state.selectedRows).forEach((rowId) => {
+      const selected = this.state.selectedRows[rowId];
+      if (selected) {
+        let rowData = selected_dictionary[rowId];
+        INCLUDED_CASE_ROWS.push(
+          <ResponseTableRow
+            key={'inc' + rowId}
+            {...{ rowData, checked: true, selectRow: () => {}, rowId }}
+          />
+        );
+      }
+    });
     return (
-      <li className="mb-4">
+      <React.Fragment>
         <p className="mb-3">
           Please select which cases you want to include in the export?
         </p>
@@ -471,7 +498,20 @@ class ExportQueue extends React.Component {
             </React.Fragment>
           )}
         </ul>
-      </li>
+      </React.Fragment>
     );
   }
+}
+
+function renderReactExportQueue(p_answer_summary) {
+  const showCustomCaseFilter =
+    p_answer_summary['case_filter_type'] == 'custom' ? true : false;
+  const caseSet = {};
+  p_answer_summary.case_set.forEach((caseId) => {
+    caseSet[caseId] = true;
+  });
+  ReactDOM.render(
+    <ExportQueue {...{ showCustomCaseFilter, caseSet }} />,
+    document.getElementById('react-content')
+  );
 }

--- a/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/selectoptions.jsx
+++ b/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/selectoptions.jsx
@@ -7,7 +7,7 @@ class SelectOptions extends React.Component {
       </option>
     ));
     return (
-      <select id={id} className="custom-select">
+      <select key={id} id={id} className="custom-select">
         {OPTS}
       </select>
     );

--- a/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/selectoptions.jsx
+++ b/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/selectoptions.jsx
@@ -1,13 +1,32 @@
 class SelectOptions extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selected: getDefaultSelected(props),
+    };
+    function getDefaultSelected({ options }) {
+      const selectedOpt = options.find((opt) => !!opt.selected);
+      return selectedOpt.value || selectedOpt.text;
+    }
+  }
+  handleChange(e) {
+    const value = e.target;
+    this.setState({ selected: value });
+  }
+
   render() {
     const { options, id } = this.props;
-    const OPTS = options.map(({ text, value, selected }) => (
-      <option key={value} value={value || text} selected={!!selected}>
-        {text}
-      </option>
-    ));
+    let selected = '';
+    const OPTS = options.map(({ text, value, selected }) => {
+      if (!!selected) selected = value || text;
+      return (
+        <option key={value || text} value={value || text}>
+          {text}
+        </option>
+      );
+    });
     return (
-      <select key={id} id={id} className="custom-select">
+      <select id={id} className="custom-select" value={this.state.selected}>
         {OPTS}
       </select>
     );

--- a/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/selectoptions.jsx
+++ b/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/selectoptions.jsx
@@ -9,10 +9,10 @@ class SelectOptions extends React.Component {
       return selectedOpt.value || selectedOpt.text;
     }
   }
-  handleChange(e) {
+  handleChange = (e) => {
     const value = e.target;
     this.setState({ selected: value });
-  }
+  };
 
   render() {
     const { options, id } = this.props;
@@ -26,7 +26,12 @@ class SelectOptions extends React.Component {
       );
     });
     return (
-      <select id={id} className="custom-select" value={this.state.selected}>
+      <select
+        id={id}
+        className="custom-select"
+        value={this.state.selected}
+        onChange={this.handleChange}
+      >
         {OPTS}
       </select>
     );

--- a/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/selectoptions.jsx
+++ b/source-code/mmria/mmria-server/wwwroot/reactjs/ExportQueue/selectoptions.jsx
@@ -1,0 +1,15 @@
+class SelectOptions extends React.Component {
+  render() {
+    const { options, id } = this.props;
+    const OPTS = options.map(({ text, value, selected }) => (
+      <option key={value} value={value || text} selected={!!selected}>
+        {text}
+      </option>
+    ));
+    return (
+      <select id={id} className="custom-select">
+        {OPTS}
+      </select>
+    );
+  }
+}

--- a/source-code/mmria/mmria-server/wwwroot/reactjs/sharedmodules/spinner.jsx
+++ b/source-code/mmria/mmria-server/wwwroot/reactjs/sharedmodules/spinner.jsx
@@ -1,0 +1,12 @@
+class Spinner extends React.Component {
+  render() {
+    const active = this.props.active ? 'spinner-active' : '';
+    return (
+      <span className={'spinner-container spinner-inline ml-2' + active}>
+        <span className="spinner-body text-primary">
+          <span className="spinner"></span>
+        </span>
+      </span>
+    );
+  }
+}

--- a/source-code/mmria/mmria-server/wwwroot/reactjs/test.jsx
+++ b/source-code/mmria/mmria-server/wwwroot/reactjs/test.jsx
@@ -1,0 +1,7 @@
+class CommentBox extends React.Component {
+  render() {
+    return <div className="commentBox">Hello, world! I am a CommentBox.</div>;
+  }
+}
+
+// ReactDOM.render(<CommentBox />, document.getElementById('reactcontent'));

--- a/source-code/mmria/mmria-server/wwwroot/scripts/export-queue/export_queue_renderer.js
+++ b/source-code/mmria/mmria-server/wwwroot/scripts/export-queue/export_queue_renderer.js
@@ -1,30 +1,34 @@
+function export_queue_render(p_queue_data, p_answer_summary, p_filter) {
+  var result = [];
 
-function export_queue_render(p_queue_data, p_answer_summary, p_filter)
-{
-	var result = [];
+  let de_identified_search_result = [];
+  render_de_identified_search_result(
+    de_identified_search_result,
+    p_answer_summary,
+    p_filter
+  );
 
-	let de_identified_search_result = [];
-	render_de_identified_search_result(de_identified_search_result, p_answer_summary, p_filter);
+  let selected_de_identified_list = [];
+  render_selected_de_identified_list(
+    selected_de_identified_list,
+    p_answer_summary
+  );
 
-	let selected_de_identified_list = [];
-	render_selected_de_identified_list(selected_de_identified_list, p_answer_summary)
-	
-	let selected_case_list = [];
-	render_selected_case_list(selected_case_list, p_answer_summary)
+  let selected_case_list = [];
+  render_selected_case_list(selected_case_list, p_answer_summary);
 
-	let pagination_html = [];
-	render_pagination(pagination_html, g_case_view_request);
-	
-	let filter_decending = "";
+  let pagination_html = [];
+  render_pagination(pagination_html, g_case_view_request);
 
-	if(g_case_view_request.descending)
-	{
-		filter_decending = "checked=true";
-	}
+  let filter_decending = '';
 
-	// console.log(g_case_view_request);
+  if (g_case_view_request.descending) {
+    filter_decending = 'checked=true';
+  }
 
-	result.push(`
+  // console.log(g_case_view_request);
+
+  result.push(`
 		<div class="row">
 			<div class="col">
 				<ol class="font-weight-bold pl-3">
@@ -44,7 +48,7 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 											 type="radio"
 											 value="all"
 											 data-prop="all_or_core"
-											 ${ p_answer_summary['all_or_core'] == 'all' ? 'checked=true' : '' }
+											 ${p_answer_summary['all_or_core'] == 'all' ? 'checked=true' : ''}
 											 onchange="setAnswerSummary(event).then(renderSummarySection(this))" />
 						<label for="all-data" class="mb-0 font-weight-normal mr-2">All</label>
 						<input name="export-type"
@@ -52,7 +56,7 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 											 type="radio"
 											 value="core"
 											 data-prop="all_or_core"
-											 ${ p_answer_summary['all_or_core'] == 'core' ? 'checked=true' : '' }
+											 ${p_answer_summary['all_or_core'] == 'core' ? 'checked=true' : ''}
 											 onchange="setAnswerSummary(event).then(renderSummarySection(this))" />
 						<label for="core-data" class="mb-0 font-weight-normal">Core</label>
 					</li>
@@ -64,7 +68,7 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 											 type="radio"
 											 value="no"
 											 data-prop="is_encrypted"
-											 ${ p_answer_summary['is_encrypted'] == 'no' ? 'checked=true' : '' }
+											 ${p_answer_summary['is_encrypted'] == 'no' ? 'checked=true' : ''}
 											 onchange="setAnswerSummary(event).then(handleElementDisplay(event, 'none')).then(renderSummarySection(this))" />
 						<label for="password-protect-no" class="mb-0 font-weight-normal mr-2">No</label>
 						<input name="password-protect"
@@ -72,10 +76,12 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 											 type="radio"
 											 value="yes"
 											 data-prop="is_encrypted"
-											 ${ p_answer_summary['is_encrypted'] == 'yes' ? 'checked' : '' }
+											 ${p_answer_summary['is_encrypted'] == 'yes' ? 'checked' : ''}
 											 onchange="setAnswerSummary(event).then(handleElementDisplay(event, 'block')).then(renderSummarySection(this))" />
 						<label for="password-protect-yes" class="mb-0 font-weight-normal">Yes</label>
-						<div class="mt-2" data-show="is_encrypted"  style="display: ${ p_answer_summary['is_encrypted'] == 'yes' ? 'block' : 'none' };">
+						<div class="mt-2" data-show="is_encrypted"  style="display: ${
+              p_answer_summary['is_encrypted'] == 'yes' ? 'block' : 'none'
+            };">
 							<label for="encryption-key" class="mb-2">Add encryption key</label>
 							<input id="encryption-key"
 										 class="form-control w-auto"
@@ -91,7 +97,11 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 											 type="radio"
 											 value="none"
 											 data-prop="de_identified_selection_type"
-											 ${ p_answer_summary.de_identified_selection_type == 'none' ? 'checked=true' : '' }
+											 ${
+                         p_answer_summary.de_identified_selection_type == 'none'
+                           ? 'checked=true'
+                           : ''
+                       }
 											 onchange="de_identify_filter_type_click(this).then(renderSummarySection(this))" /> 
 						<label for="de-identify-none" class="mb-0 font-weight-normal mr-2">None</label>
 						<input name="de-identify"
@@ -99,7 +109,12 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 											 type="radio"
 											 value="standard"
 											 data-prop="de_identified_selection_type"
-											 ${ p_answer_summary.de_identified_selection_type == 'standard' ? 'checked=true' : '' }
+											 ${
+                         p_answer_summary.de_identified_selection_type ==
+                         'standard'
+                           ? 'checked=true'
+                           : ''
+                       }
 											 onchange="de_identify_filter_type_click(this).then(renderSummarySection(this))" />
 						<label for="de-identify-standard" class="mb-0 font-weight-normal mr-2">Standard</label>
 						<input name="de-identify"
@@ -107,10 +122,19 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 											 type="radio"
 											 value="custom"
 											 data-prop="de_identified_selection_type"
-											 ${ p_answer_summary.de_identified_selection_type == 'custom' ? 'checked=true' : '' }
+											 ${
+                         p_answer_summary.de_identified_selection_type ==
+                         'custom'
+                           ? 'checked=true'
+                           : ''
+                       }
 											 onchange="de_identify_filter_type_click(this).then(renderSummarySection(this))" />
 						<label for="de-identify-custom" class="mb-0 font-weight-normal">Custom</label>
-						<div id="de_identify_filter_standard" class="p-3 mt-3 bg-gray-l3" data-prop="de_identified_selection_type" style="display: ${p_answer_summary.de_identified_selection_type == 'standard' ? 'block' : 'none'}; border: 1px solid #bbb;">
+						<div id="de_identify_filter_standard" class="p-3 mt-3 bg-gray-l3" data-prop="de_identified_selection_type" style="display: ${
+              p_answer_summary.de_identified_selection_type == 'standard'
+                ? 'block'
+                : 'none'
+            }; border: 1px solid #bbb;">
 							<div class="" style="border: 1px solid #bbbbbb; overflow:hidden; overflow-y: auto; max-height: 346px;">
 								<table class="table rounded-0 mb-0">
 									<thead class="thead">
@@ -136,7 +160,11 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 								</table>
 							</div>
 						</div>
-						<div id="de_identify_filter" class="p-3 mt-3 bg-gray-l3" data-prop="de_identified_selection_type" style="display: ${p_answer_summary.de_identified_selection_type == 'custom' ? 'block' : 'none'}; border: 1px solid #bbb;">
+						<div id="de_identify_filter" class="p-3 mt-3 bg-gray-l3" data-prop="de_identified_selection_type" style="display: ${
+              p_answer_summary.de_identified_selection_type == 'custom'
+                ? 'block'
+                : 'none'
+            }; border: 1px solid #bbb;">
 							<p class="font-weight-bold">To customize, please search/choose your options below and check the resulting fields you want to de-identify from the list.</p>
 							<div class="form-inline mb-2">
 								<label for="de_identify_search_text" class="mr-2"> Search for:</label>
@@ -151,7 +179,11 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 								<span class="spinner-container spinner-inline ml-2"><span class="spinner-body text-primary"><span class="spinner"></span></span></span>
 							</div>
 							<div class="form-group form-check mb-0">
-								<input type="checkbox" class="form-check-input" id="include_pii" onchange="de_identify_standard_fields_change(this.checked)" ${ p_answer_summary.is_de_identify_standard_fields == true ? 'checked=true': ''} >
+								<input type="checkbox" class="form-check-input" id="include_pii" onchange="de_identify_standard_fields_change(this.checked)" ${
+                  p_answer_summary.is_de_identify_standard_fields == true
+                    ? 'checked=true'
+                    : ''
+                } >
 								<label class="form-check-label font-weight-normal" for="include_pii">De-identify standard fields</label>
 							</div>
 							
@@ -167,7 +199,7 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 										</tr>
 									</thead>
 									<tbody class="tbody" id="de_identify_search_result_list">
-										${de_identified_search_result.join("")}
+										${de_identified_search_result.join('')}
 									</tbody>
 								</table>
 							</div>
@@ -178,13 +210,15 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 										<tr class="tr bg-tertiary">
 											<th class="th" colspan="2" scope="colgroup">
 												<span class="row no-gutters justify-content-between">
-													<span id="de_identified_count">Fields that have been de-identified (${p_answer_summary.de_identified_field_set.length})</span>
+													<span id="de_identified_count">Fields that have been de-identified (${
+                            p_answer_summary.de_identified_field_set.length
+                          })</span>
 												</span>
 											</th>
 										</tr>
 									</thead>
 									<tbody class="tbody" id="selected_de_identified_field_list">
-										${selected_de_identified_list.join("")}
+										${selected_de_identified_list.join('')}
 									</tbody>
 								</table>
 							</div>
@@ -199,7 +233,7 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 										 name="case_filter_type"
 										 value="all"
 										 data-prop="case_filter_type"
-										 ${ p_answer_summary['case_filter_type'] == 'all' ? 'checked=true' : '' }
+										 ${p_answer_summary['case_filter_type'] == 'all' ? 'checked=true' : ''}
 										 onclick="case_filter_type_click(this)" /> All
 						</label>
 						<label for="case_filter_type_custom" class="font-weight-normal">
@@ -208,10 +242,14 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 										 name="case_filter_type"
 										 value="custom"
 										 data-prop="case_filter_type"
-										 ${ p_answer_summary['case_filter_type'] == 'custom' ? 'checked=true' : '' }
+										 ${p_answer_summary['case_filter_type'] == 'custom' ? 'checked=true' : ''}
 										 onclick="case_filter_type_click(this)" /> Custom
 						</label>
-						<ul class="font-weight-bold list-unstyled mt-3" id="custom_case_filter" style="display:${ p_answer_summary['case_filter_type'] == 'custom' ? 'block' : 'none' }">
+						<ul class="font-weight-bold list-unstyled mt-3" id="custom_case_filter" style="display:${
+              p_answer_summary['case_filter_type'] == 'custom'
+                ? 'block'
+                : 'none'
+            }">
 							<li class="mb-4" >
 								<div class="form-inline mb-2">
 									<label for="filter_search_text" class="font-weight-normal mr-2">Search for:</label>
@@ -244,7 +282,7 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 
 							<li class="mb-3" style="overflow:hidden; overflow-y: auto; height: 360px; border: 1px solid #ced4da;">
 								<div id='case_result_pagination' class='table-pagination row align-items-center no-gutters pt-1 pb-1 pl-2 pr-2'>
-									${pagination_html.join("")}
+									${pagination_html.join('')}
 								</div>
 								<table class="table rounded-0 m-0">
 									<thead class="thead">
@@ -281,7 +319,9 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 										<tr class="tr bg-tertiary">
 											<th class="th" colspan="14" scope="colgroup">
 												<span class="row no-gutters justify-content-between">
-													<span id="exported_cases_count">Cases to be included in export (${p_answer_summary.case_set.length}):</span>
+													<span id="exported_cases_count">Cases to be included in export (${
+                            p_answer_summary.case_set.length
+                          }):</span>
 													<!--button class="anti-btn" onclick="fooBarSelectAll()">Deselect All</button-->
 												</span>
 											</th>
@@ -300,7 +340,7 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 										</tr>
 									</thead>
 									<tbody id="selected_case_list" class="tbody">
-										${selected_case_list.join("")}
+										${selected_case_list.join('')}
 									</tbody>
 								</table>
 							</li>
@@ -310,7 +350,7 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 			</div>
 		</div>
 	`);
-/*
+  /*
 	result.push("<hr/>");
 
 	result.push('<p>Click on Export Core Data to CSV format to produce a zip file that contains your core data export plus a data dictionary. The zip file will be downloaded directly to the “Downloads” folder in the local environment of your computer.</p>');
@@ -338,16 +378,16 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 
 */
 
-	// result.push("<ul>");
-	// 	result.push("<li><input type='button' value='Export Core Data to CSV format.' onclick='add_new_core_export_item()'/>");
-	// 	result.push("<br/>Click on Export Core Data to CSV format to produce a zip file that contains your core data export plus a data dictionary. The zip file will be downloaded directly to the “Downloads” folder in the local environment of your computer.<br/>Contains 2 Files<ul><li>core_export.csv</li><li>data-dictionary.csv <p>Details of the data dictionary format can be found here: <a target='_data_dictionary' href='/data-dictionary'>data-dictionary-format</a></p></li></ul></li>");
-	// 	result.push("<li><input type='button' value='Export All Data to  CSV format.' onclick='add_new_all_export_item()'/>");
-	// 	result.push("<br/>Click on Export All Data to CSV format to produce a zip file that contains 59 case data files plus a data dictionary. The zip file will be downloaded directly to the “Downloads” folder in the local environment of your computer.<br/>Contains a total of 60 files:<ul><li>59 *.csv</li><li>data-dictionary.csv <p>Details of the data dictionary format can be found here: <a target='_data_dictionary' href='/data-dictionary'>data-dictionary-format</a></p></li></ul></li>");
-	// 	//result.push("<li><input type='button' value='Export All Data to  Deidentified CDC CSV format.' onclick='add_new_cdc_export_item()'/></li>");
-	// 	//result.push("<li><input type='button' value='All Data to MMRIA JSON format.' onclick='add_new_json_export_item()'/></li>");
-	// result.push("</ul>");
+  // result.push("<ul>");
+  // 	result.push("<li><input type='button' value='Export Core Data to CSV format.' onclick='add_new_core_export_item()'/>");
+  // 	result.push("<br/>Click on Export Core Data to CSV format to produce a zip file that contains your core data export plus a data dictionary. The zip file will be downloaded directly to the “Downloads” folder in the local environment of your computer.<br/>Contains 2 Files<ul><li>core_export.csv</li><li>data-dictionary.csv <p>Details of the data dictionary format can be found here: <a target='_data_dictionary' href='/data-dictionary'>data-dictionary-format</a></p></li></ul></li>");
+  // 	result.push("<li><input type='button' value='Export All Data to  CSV format.' onclick='add_new_all_export_item()'/>");
+  // 	result.push("<br/>Click on Export All Data to CSV format to produce a zip file that contains 59 case data files plus a data dictionary. The zip file will be downloaded directly to the “Downloads” folder in the local environment of your computer.<br/>Contains a total of 60 files:<ul><li>59 *.csv</li><li>data-dictionary.csv <p>Details of the data dictionary format can be found here: <a target='_data_dictionary' href='/data-dictionary'>data-dictionary-format</a></p></li></ul></li>");
+  // 	//result.push("<li><input type='button' value='Export All Data to  Deidentified CDC CSV format.' onclick='add_new_cdc_export_item()'/></li>");
+  // 	//result.push("<li><input type='button' value='All Data to MMRIA JSON format.' onclick='add_new_json_export_item()'/></li>");
+  // result.push("</ul>");
 
-	result.push(`
+  result.push(`
 		<div class="row">
 			<div class="col">
 				${export_queue_comfirm_render(p_answer_summary)}
@@ -355,37 +395,39 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 		</div>
 	`);
 
-	result.push('<table class="table mt-4 mb-0">');
-		result.push('<thead class="thead">');
-			result.push('<tr class="tr bg-tertiary"><th class="th h4" colspan="8" scope="colgroup">Export Request History</th></tr>');
-			result.push('<tr class="tr bg-quaternary"><th class="th" colspan="8" scope="colgroup">(*Please note that the export queue is deleted at midnight each day.)</th></tr>');
-			result.push('<tr class="tr">');
-				result.push('<th class="th" scope="col">Date created</th>');
-				result.push('<th class="th" scope="col">Created by</th>');
-				result.push('<th class="th" scope="col">Date last updated</th>');
-				result.push('<th class="th" scope="col">Last updated by</th>');
-				result.push('<th class="th" scope="col">File name</th>');
-				result.push('<th class="th" scope="col">Export type</th>');
-				result.push('<th class="th" scope="col">Status</th>');
-				result.push('<th class="th" scope="col">Action</th>');
-			result.push('</tr>');
-		result.push('</thead>');
-		result.push('<tbody class="tbody">');
-			for(var i = 0; i < p_queue_data.length; i++)
-			{
-				var item = p_queue_data[i];
+  result.push('<table class="table mt-4 mb-0">');
+  result.push('<thead class="thead">');
+  result.push(
+    '<tr class="tr bg-tertiary"><th class="th h4" colspan="8" scope="colgroup">Export Request History</th></tr>'
+  );
+  result.push(
+    '<tr class="tr bg-quaternary"><th class="th" colspan="8" scope="colgroup">(*Please note that the export queue is deleted at midnight each day.)</th></tr>'
+  );
+  result.push('<tr class="tr">');
+  result.push('<th class="th" scope="col">Date created</th>');
+  result.push('<th class="th" scope="col">Created by</th>');
+  result.push('<th class="th" scope="col">Date last updated</th>');
+  result.push('<th class="th" scope="col">Last updated by</th>');
+  result.push('<th class="th" scope="col">File name</th>');
+  result.push('<th class="th" scope="col">Export type</th>');
+  result.push('<th class="th" scope="col">Status</th>');
+  result.push('<th class="th" scope="col">Action</th>');
+  result.push('</tr>');
+  result.push('</thead>');
+  result.push('<tbody class="tbody">');
+  for (var i = 0; i < p_queue_data.length; i++) {
+    var item = p_queue_data[i];
 
-				result.push('<tr class="tr">');
-					result.push(`<td class="td">${item.date_created}</td>`);
-					result.push(`<td class="td">${item.created_by}</td>`);
-					result.push(`<td class="td">${item.date_last_updated}</td>`);
-					result.push(`<td class="td">${item.last_updated_by}</td>`);
-					result.push(`<td class="td">${item.file_name}</td>`);
-					result.push(`<td class="td">${item.export_type}</td>`);
+    result.push('<tr class="tr">');
+    result.push(`<td class="td">${item.date_created}</td>`);
+    result.push(`<td class="td">${item.created_by}</td>`);
+    result.push(`<td class="td">${item.date_last_updated}</td>`);
+    result.push(`<td class="td">${item.last_updated_by}</td>`);
+    result.push(`<td class="td">${item.file_name}</td>`);
+    result.push(`<td class="td">${item.export_type}</td>`);
 
-					if(item.status.includes('Queue'))
-					{
-						result.push(`
+    if (item.status.includes('Queue')) {
+      result.push(`
 							<td class="td">
 								<span class="spinner-container spinner-small spinner-active">
 									<span class="spinner-body text-primary">
@@ -395,10 +437,8 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 								</span>
 							</td>
 						`);
-					}
-					else if(item.status.includes('Creating'))
-					{
-						result.push(`
+    } else if (item.status.includes('Creating')) {
+      result.push(`
 							<td class="td">
 								<span class="spinner-container spinner-small spinner-active">
 									<span class="spinner-body text-primary">
@@ -408,57 +448,61 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter)
 								</span>
 							</td>
 						`);
-					}
-					else
-					{
-						result.push(`<td class="td">${item.status}</td>`);
-					}
+    } else {
+      result.push(`<td class="td">${item.status}</td>`);
+    }
 
-					if(item.status == "Confirmation Required")
-					{
-						result.push(`<td class="td"><input type='button' value='Confirm' onclick='confirm_export_item("${item._id}")' /> | <input type='button' value='Cancel' onclick='cancel_export_item("${item._id}")' /></td>`);
-					}
-					else if(item.status == "Download")
-					{
-						result.push(`<td class="td"><input type='button' value='Download' onclick='download_export_item("${item._id}")' /></td>`);
-					}
-					else if(item.status == "Downloaded")
-					{
-						result.push(`<td class="td"><input type='button' value='Download' onclick='download_export_item("${item._id}")' /> | <input type='button' value='Delete' onclick='delete_export_item("${item._id}")' /></td>`);
-					}
-					else 
-					{
-						result.push("<td>&nbsp;</td>");	
-					}
-				result.push("</tr>")
-			}
-		result.push("</tbody>");
-	result.push("</table>");
+    if (item.status == 'Confirmation Required') {
+      result.push(
+        `<td class="td"><input type='button' value='Confirm' onclick='confirm_export_item("${item._id}")' /> | <input type='button' value='Cancel' onclick='cancel_export_item("${item._id}")' /></td>`
+      );
+    } else if (item.status == 'Download') {
+      result.push(
+        `<td class="td"><input type='button' value='Download' onclick='download_export_item("${item._id}")' /></td>`
+      );
+    } else if (item.status == 'Downloaded') {
+      result.push(
+        `<td class="td"><input type='button' value='Download' onclick='download_export_item("${item._id}")' /> | <input type='button' value='Delete' onclick='delete_export_item("${item._id}")' /></td>`
+      );
+    } else {
+      result.push('<td>&nbsp;</td>');
+    }
+    result.push('</tr>');
+  }
+  result.push('</tbody>');
+  result.push('</table>');
 
-	return result;
+  return result;
 }
 
 function renderSummarySection(el) {
-	let val = capitalizeFirstLetter(el.value);
-	let prop = el.dataset.prop;
-	const props = document.querySelectorAll(`#answer-summary-card [data-prop="${prop}"]`);
+  let val = capitalizeFirstLetter(el.value);
+  let prop = el.dataset.prop;
+  const props = document.querySelectorAll(
+    `#answer-summary-card [data-prop="${prop}"]`
+  );
 
-	props.forEach((el) =>
-	{
-		el.innerText = capitalizeFirstLetter(val);
-	})
+  props.forEach((el) => {
+    el.innerText = capitalizeFirstLetter(val);
+  });
 
-	var summary_of_de_identified_fields = document.getElementById("summary_of_de_identified_fields");
-	summary_of_de_identified_fields.innerHTML = render_summary_de_identified_fields(answer_summary);
-	
-	var summary_of_selected_cases = document.getElementById("summary_of_selected_cases");
-	summary_of_selected_cases.innerHTML = render_summary_of_selected_cases(answer_summary);
+  var summary_of_de_identified_fields = document.getElementById(
+    'summary_of_de_identified_fields'
+  );
+  summary_of_de_identified_fields.innerHTML = render_summary_de_identified_fields(
+    answer_summary
+  );
+
+  var summary_of_selected_cases = document.getElementById(
+    'summary_of_selected_cases'
+  );
+  summary_of_selected_cases.innerHTML = render_summary_of_selected_cases(
+    answer_summary
+  );
 }
 
-
-function export_queue_comfirm_render(p_answer_summary)
-{
-	var result = `
+function export_queue_comfirm_render(p_answer_summary) {
+  var result = `
 		<div id="answer-summary-card" class="card">
 			<div class="card-header bg-gray-l3">
 				<h2 class="h5 font-weight-bold">Summary of your Export Data choices</h2>
@@ -470,27 +514,37 @@ function export_queue_comfirm_render(p_answer_summary)
 					</li>
 
 					<li>
-						Export <span data-prop="all_or_core">${capitalizeFirstLetter(p_answer_summary.all_or_core)}</span> data
+						Export <span data-prop="all_or_core">${capitalizeFirstLetter(
+              p_answer_summary.all_or_core
+            )}</span> data
 						<ul>
 							<li>
-								Exporting <span data-prop="all_or_core">${capitalizeFirstLetter(p_answer_summary.all_or_core)}</span> data and a <a href="/data-dictionary" target="_blank">data dictionary</a>
+								Exporting <span data-prop="all_or_core">${capitalizeFirstLetter(
+                  p_answer_summary.all_or_core
+                )}</span> data and a <a href="/data-dictionary" target="_blank">data dictionary</a>
 							</li>
 						</ul>
 					</li>
 
 					<li>
-						Password protected: <span data-prop="is_encrypted">${capitalizeFirstLetter(p_answer_summary.is_encrypted)}</span>
+						Password protected: <span data-prop="is_encrypted">${capitalizeFirstLetter(
+              p_answer_summary.is_encrypted
+            )}</span>
 					</li>
 
 					<li>
-						De-identify fields: <span data-prop="de_identified_selection_type">${capitalizeFirstLetter(p_answer_summary.de_identified_selection_type)}</span>
+						De-identify fields: <span data-prop="de_identified_selection_type">${capitalizeFirstLetter(
+              p_answer_summary.de_identified_selection_type
+            )}</span>
 						<div id="summary_of_de_identified_fields" class="" style="max-height:120px; overflow:auto">
 							${render_summary_de_identified_fields(p_answer_summary)}
 						</div>
 					</li>
 					
 					<li>
-						Filter by: <span data-prop="case_filter_type">${capitalizeFirstLetter(p_answer_summary.case_filter_type)}</span>
+						Filter by: <span data-prop="case_filter_type">${capitalizeFirstLetter(
+              p_answer_summary.case_filter_type
+            )}</span>
 						<div id="summary_of_selected_cases" class="" style="max-height:120px; overflow:auto">
 							${render_summary_of_selected_cases(p_answer_summary)}
 						</div>
@@ -503,276 +557,253 @@ function export_queue_comfirm_render(p_answer_summary)
 		</div>
 	`;
 
-	return result;
-}
-
-
-// Function returned after promise to update/set answer_summary to new value
-function updateSummarySection(event)
-{
-	const tar = event.target;
-	const prop = tar.dataset.prop;
-	const val = tar.value;
-	const el = document.querySelectorAll(`#answer-summary-card [data-prop='${prop}']`);
-	let path;
-
-		// if prop doesn't have path
-	if (prop.indexOf('/') < 0) 
-	{
-		el.forEach((i) =>
-		{
-			i.innerText = capitalizeFirstLetter(val);
-		});
-	}
-	else
-	{
-		path = prop.split('/');
-		switch(path[1]) {
-			case 'case_status':
-				const cs_opts = tar.options;
-				let cs_html = '';
-				for (let i = 0; i < cs_opts.length; i++) {
-					if (cs_opts[i].selected) {
-						cs_html += '<li>';
-						cs_html += cs_opts[i].text;
-						cs_html += '</li>';
-					}
-				}
-				el[0].innerHTML = cs_html;
-				break;
-
-			case 'case_jurisdiction':
-				const cj_opts = tar.options;
-				let cj_html = '';
-				for (let i = 0; i < cj_opts.length; i++) {
-					if (cj_opts[i].selected) {
-						cj_html += '<li>';
-						cj_html += cj_opts[i].text;
-						cj_html += '</li>';
-					}
-				}
-				el[0].innerHTML = cj_html;
-				break;
-			default:
-				el.forEach((i) =>
-				{
-					i.innerText = capitalizeFirstLetter(val);
-				});
-				break;
-		}
-	}
+  return result;
 }
 
 // Function returned after promise to update/set answer_summary to new value
-function handleElementDisplay(event, str)
-{
-	const prop = event.target.dataset.prop;
-	const tars = document.querySelectorAll(`[data-show='${prop}']`);
+function updateSummarySection(event) {
+  const tar = event.target;
+  const prop = tar.dataset.prop;
+  const val = tar.value;
+  const el = document.querySelectorAll(
+    `#answer-summary-card [data-prop='${prop}']`
+  );
+  let path;
 
-	return new Promise ((resolve, reject) =>
-	{
-		if (!isNullOrUndefined(tars)) {
-			for (let i = 0; i < tars.length; i++) {
-				if (tars[i].style.display === 'none') {
-					tars[i].style.display = str;
-				} else {
-					tars[i].style.display = 'none';
-				}
-			}
-			resolve();
-		} else {
-			// target doesn't exist, reject
-			reject('Target(s) do not exist');
-		}
-	})
+  // if prop doesn't have path
+  if (prop.indexOf('/') < 0) {
+    el.forEach((i) => {
+      i.innerText = capitalizeFirstLetter(val);
+    });
+  } else {
+    path = prop.split('/');
+    switch (path[1]) {
+      case 'case_status':
+        const cs_opts = tar.options;
+        let cs_html = '';
+        for (let i = 0; i < cs_opts.length; i++) {
+          if (cs_opts[i].selected) {
+            cs_html += '<li>';
+            cs_html += cs_opts[i].text;
+            cs_html += '</li>';
+          }
+        }
+        el[0].innerHTML = cs_html;
+        break;
 
-	// tars.forEach((el) =>
-	// {
-	// 	if (el.style.display == 'none') {
-	// 		el.style.display == str;
-	// 		console.log('a');
-	// 	} else {
-	// 		el.style.display == 'none';
-	// 		console.log('b');
-	// 	}
-	// });
+      case 'case_jurisdiction':
+        const cj_opts = tar.options;
+        let cj_html = '';
+        for (let i = 0; i < cj_opts.length; i++) {
+          if (cj_opts[i].selected) {
+            cj_html += '<li>';
+            cj_html += cj_opts[i].text;
+            cj_html += '</li>';
+          }
+        }
+        el[0].innerHTML = cj_html;
+        break;
+      default:
+        el.forEach((i) => {
+          i.innerText = capitalizeFirstLetter(val);
+        });
+        break;
+    }
+  }
+}
+
+// Function returned after promise to update/set answer_summary to new value
+function handleElementDisplay(event, str) {
+  const prop = event.target.dataset.prop;
+  const tars = document.querySelectorAll(`[data-show='${prop}']`);
+
+  return new Promise((resolve, reject) => {
+    if (!isNullOrUndefined(tars)) {
+      for (let i = 0; i < tars.length; i++) {
+        if (tars[i].style.display === 'none') {
+          tars[i].style.display = str;
+        } else {
+          tars[i].style.display = 'none';
+        }
+      }
+      resolve();
+    } else {
+      // target doesn't exist, reject
+      reject('Target(s) do not exist');
+    }
+  });
+
+  // tars.forEach((el) =>
+  // {
+  // 	if (el.style.display == 'none') {
+  // 		el.style.display == str;
+  // 		console.log('a');
+  // 	} else {
+  // 		el.style.display == 'none';
+  // 		console.log('b');
+  // 	}
+  // });
 }
 
 // Class to dynamically create a new 'numeric' dropdown
-class NumericDropdown
-{
-	constructor(type)
-	{
-		this.type = type;
-		this.iterator = 1;
-		this.condition = 1;
-		this.opts = '<option value="all" selected>All</option>'; // options should be 'All' by default
-	}
+class NumericDropdown {
+  constructor(type) {
+    this.type = type;
+    this.iterator = 1;
+    this.condition = 1;
+    this.opts = '<option value="all" selected>All</option>'; // options should be 'All' by default
+  }
 
-	buildNumericDropdown()
-	{
-		// based on case type, we change iterator and/or condition
-		switch (this.type)
-		{
-			case "y":
-			case "year":
-				this.iterator = new Date().getFullYear() - 119;
-				this.condition = new Date().getFullYear();
-				break;
-			case "m":
-			case "month":
-				this.condition = 12;
-				break;
-			case "d":
-			case "day":
-				this.condition = 31;
-				break;
-		}
+  buildNumericDropdown() {
+    // based on case type, we change iterator and/or condition
+    switch (this.type) {
+      case 'y':
+      case 'year':
+        this.iterator = new Date().getFullYear() - 119;
+        this.condition = new Date().getFullYear();
+        break;
+      case 'm':
+      case 'month':
+        this.condition = 12;
+        break;
+      case 'd':
+      case 'day':
+        this.condition = 31;
+        break;
+    }
 
-		// iterate through iterator and condition to build the options
-		for (let i = this.iterator; i <= this.condition; i++)
-		{
-			this.opts += `<option value='${i}'>`;
-			this.opts += i;
-			this.opts += "</option>";
-		}
-		return this.opts;
-	}
+    // iterate through iterator and condition to build the options
+    for (let i = this.iterator; i <= this.condition; i++) {
+      this.opts += `<option value='${i}'>`;
+      this.opts += i;
+      this.opts += '</option>';
+    }
+    return this.opts;
+  }
 }
 
+function apply_filter_button_click() {
+  var filter_search_text = document.getElementById('filter_search_text');
+  var filter_sort_by = document.getElementById('filter_sort_by');
+  var filter_records_perPage = document.getElementById(
+    'filter_records_perPage'
+  );
+  var filter_decending = document.getElementById('filter_decending');
 
-function apply_filter_button_click()
-{
-	var filter_search_text = document.getElementById("filter_search_text");
-	var filter_sort_by = document.getElementById("filter_sort_by");
-	var filter_records_perPage = document.getElementById("filter_records_perPage");
-	var filter_decending = document.getElementById("filter_decending");
-
-	/*
+  /*
 	g_case_view_request.total_rows = 0,
 	g_case_view_request.page = 1,
 	g_case_view_request.skip = 0,
 	*/
 
-	g_case_view_request.take = filter_records_perPage.value;
-	g_case_view_request.sort = filter_sort_by.value;
-	g_case_view_request.search_key = filter_search_text.value;
-	g_case_view_request.descending = filter_decending.checked;
-	
-	get_case_set();
+  g_case_view_request.take = filter_records_perPage.value;
+  g_case_view_request.sort = filter_sort_by.value;
+  g_case_view_request.search_key = filter_search_text.value;
+  g_case_view_request.descending = filter_decending.checked;
+
+  get_case_set();
 }
 
-function result_checkbox_click(p_checkbox)
-{
-	let value = p_checkbox.value;
+function result_checkbox_click(p_checkbox) {
+  let value = p_checkbox.value;
 
-	if(p_checkbox.checked)
-	{
+  if (p_checkbox.checked) {
+    if (answer_summary.case_set.indexOf(value) < 0) {
+      answer_summary.case_set.push(value);
+    }
+  } else {
+    let index = answer_summary.case_set.indexOf(value);
 
-		if(answer_summary.case_set.indexOf(value) < 0)
-		{
-			answer_summary.case_set.push(value)
-		}
-	}
-	else
-	{
-		let index = answer_summary.case_set.indexOf(value);
+    if (index > -1) {
+      answer_summary.case_set.splice(index, 1);
+    }
+  }
 
-		if(index > -1)
-		{
-			answer_summary.case_set.splice(index,1)
-		}
-	}
+  let el = document.getElementById('selected_case_list');
+  let result = [];
 
-	let el = document.getElementById('selected_case_list');
-	let result = [];
+  render_selected_case_list(result, answer_summary);
+  el.innerHTML = result.join('');
 
-	render_selected_case_list(result, answer_summary);
-	el.innerHTML = result.join("");
+  el = document.getElementById('exported_cases_count');
+  el.innerHTML = `Cases to be included in export (${answer_summary.case_set.length}):`;
 
-	el = document.getElementById('exported_cases_count');
-	el.innerHTML = `Cases to be included in export (${answer_summary.case_set.length}):`;
+  el = document.getElementById('case_result_pagination');
+  result = [];
+  render_pagination(result, g_case_view_request);
+  el.innerHTML = result.join('');
 
-
-	el = document.getElementById('case_result_pagination');
-	result = [];
-	render_pagination(result, g_case_view_request);
-	el.innerHTML = result.join("");
-
-
-	var summary_of_selected_cases = document.getElementById("summary_of_selected_cases");
-	summary_of_selected_cases.innerHTML = render_summary_of_selected_cases(answer_summary);
+  var summary_of_selected_cases = document.getElementById(
+    'summary_of_selected_cases'
+  );
+  summary_of_selected_cases.innerHTML = render_summary_of_selected_cases(
+    answer_summary
+  );
 }
-
 
 var g_case_view_request = {
-	total_rows: 0,
-	page :1,
-	skip : 0,
-	take : 100,
-	sort : "date_last_updated",
-	search_key : null,
-	descending : true,
-	get_query_string : function(){
-		var result = [];
-		result.push("?skip=" + (this.page - 1) * this.take);
-		result.push("take=" + this.take);
-		result.push("sort=" + this.sort);
+  total_rows: 0,
+  page: 1,
+  skip: 0,
+  take: 100,
+  sort: 'date_last_updated',
+  search_key: null,
+  descending: true,
+  get_query_string: function () {
+    var result = [];
+    result.push('?skip=' + (this.page - 1) * this.take);
+    result.push('take=' + this.take);
+    result.push('sort=' + this.sort);
 
-		if(this.search_key)
-		{
-			result.push("search_key=\"" + this.search_key.replace(/"/g, '\\"').replace(/\n/g,"\\n") + "\"");
-		}
+    if (this.search_key) {
+      result.push(
+        'search_key="' +
+          this.search_key.replace(/"/g, '\\"').replace(/\n/g, '\\n') +
+          '"'
+      );
+    }
 
-		result.push("descending=" + this.descending);
-		
-		// console.log(this);
+    result.push('descending=' + this.descending);
 
-		return result.join("&");
-	}
+    // console.log(this);
+
+    return result.join('&');
+  },
 };
 
+function get_case_set() {
+  var case_view_url =
+    location.protocol +
+    '//' +
+    location.host +
+    '/api/case_view' +
+    g_case_view_request.get_query_string();
 
-function get_case_set()
-{
-	var case_view_url = location.protocol + '//' + location.host + '/api/case_view' + g_case_view_request.get_query_string();
+  $.ajax({
+    url: case_view_url,
+  }).done(function (case_view_response) {
+    let el = document.getElementById('search_result_list');
+    let html = [];
+    //html.push("<li><input type='checkbox' /> select all</li>");
+    g_case_view_request.total_rows = case_view_response.total_rows;
+    g_case_view_request.respone_rows = case_view_response.rows;
+    //g_case_view_request.page = case_view_response.page;
 
-	$.ajax
-	(
-		{
-			url: case_view_url,
-		}
-	)
-	.done
-	(
-		function(case_view_response) 
-		{
-			let el = document.getElementById('search_result_list');
-			let html = [];
-			//html.push("<li><input type='checkbox' /> select all</li>");
-			g_case_view_request.total_rows = case_view_response.total_rows;
-			g_case_view_request.respone_rows = case_view_response.rows;
-			//g_case_view_request.page = case_view_response.page;
-			
-			for(let i = 0; i < case_view_response.rows.length; i++)
-			{
+    for (let i = 0; i < case_view_response.rows.length; i++) {
+      let item = case_view_response.rows[i];
+      let value_list = item.value;
 
+      selected_dictionary[item.id] = value_list;
 
-				let item = case_view_response.rows[i];
-				let value_list = item.value;
+      let checked = '';
+      let index = answer_summary.case_set.indexOf(item.id);
 
-				selected_dictionary[item.id] = value_list;
+      if (index > -1) {
+        checked = 'checked=true';
+      }
 
-				let checked = "";
-				let index = answer_summary.case_set.indexOf(item.id);
-
-				if(index > -1)
-				{
-					checked = "checked=true"
-				}
-
-				// Items generated after user applies filters
-				html.push(`
+      // Items generated after user applies filters
+      html.push(`
 					<tr class="tr font-weight-normal">
 						<td class="td" data-type="date_created" width="38" align="center">
 							<input id=${escape(item.id)}
@@ -783,65 +814,83 @@ function get_case_set()
 							<label for="" class="sr-only">${escape(item.id)}</label>
 						</td>
 						<td class="td" data-type="date_last_updated">
-							${escape(value_list.date_last_updated).replace(/%20/g," ").replace(/%3A/g,"-")} <br/> ${escape(value_list.last_updated_by)}
+							${escape(value_list.date_last_updated)
+                .replace(/%20/g, ' ')
+                .replace(/%3A/g, '-')} <br/> ${escape(
+        value_list.last_updated_by
+      )}
 						</td>
 						<td class="td" data-type="jurisdiction_id">
-							${escape(value_list.last_name).replace(/%20/g," ").replace(/%3A/g,"-")}, ${escape(value_list.first_name).replace(/%20/g," ").replace(/%3A/g,"-")} ${escape(value_list.middle_name).replace(/%20/g," ").replace(/%3A/g,"-")} [${escape(value_list.jurisdiction_id)}]  
+							${escape(value_list.last_name)
+                .replace(/%20/g, ' ')
+                .replace(/%3A/g, '-')}, ${escape(value_list.first_name)
+        .replace(/%20/g, ' ')
+        .replace(/%3A/g, '-')} ${escape(value_list.middle_name)
+        .replace(/%20/g, ' ')
+        .replace(/%3A/g, '-')} [${escape(value_list.jurisdiction_id)}]  
 						</td>
 						<td class="td" data-type="record_id">
-							${escape(value_list.record_id).replace(/%20/g," ").replace(/%3A/g,"-")}
+							${escape(value_list.record_id).replace(/%20/g, ' ').replace(/%3A/g, '-')}
 						</td>
 						<td class="td" data-type="date_of_death">
-						${(value_list.date_of_death_year != null)? escape(value_list.date_of_death_year): "" }-${(value_list.date_of_death_month != null)? escape(value_list.date_of_death_month) : ""}
+						${
+              value_list.date_of_death_year != null
+                ? escape(value_list.date_of_death_year)
+                : ''
+            }-${
+        value_list.date_of_death_month != null
+          ? escape(value_list.date_of_death_month)
+          : ''
+      }
 						</td>
 						<td class="td" data-type="committee_review_date">
-						${(value_list.committee_review_date!=null)? escape(value_list.committee_review_date): "N/A"}
+						${
+              value_list.committee_review_date != null
+                ? escape(value_list.committee_review_date)
+                : 'N/A'
+            }
 						</td>
 						<td class="td" data-type="agency_case_id">
-							${escape(value_list.agency_case_id).replace(/%20/g," ").replace(/%3A/g,"-")}
+							${escape(value_list.agency_case_id).replace(/%20/g, ' ').replace(/%3A/g, '-')}
 						</td>
 						<td class="td" data-type="date_last_updated">
-							${escape(value_list.date_last_updated).replace(/%20/g," ").replace(/%3A/g,"-")}<br/>
-							${escape(value_list.created_by).replace(/%20/g," ").replace(/%3A/g,"-")}
+							${escape(value_list.date_last_updated)
+                .replace(/%20/g, ' ')
+                .replace(/%3A/g, '-')}<br/>
+							${escape(value_list.created_by).replace(/%20/g, ' ').replace(/%3A/g, '-')}
 						</td>
 					</tr>
 				`);
-				// html.push(`<li class="foo"><input value=${escape(item.id)} type="checkbox" onclick="result_checkbox_click(this)" ${checked} /> ${escape(value_list.jurisdiction_id)} ${escape(value_list.last_name)},${escape(value_list.first_name)} ${escape(value_list.date_of_death_year)}/${escape(value_list.date_of_death_month)} ${escape(value_list.date_last_updated)} ${escape(value_list.last_updated_by)} agency_id:${escape(value_list.agency_case_id)} rc_id:${escape(value_list.record_id)}</li>`);
-			}
+      // html.push(`<li class="foo"><input value=${escape(item.id)} type="checkbox" onclick="result_checkbox_click(this)" ${checked} /> ${escape(value_list.jurisdiction_id)} ${escape(value_list.last_name)},${escape(value_list.first_name)} ${escape(value_list.date_of_death_year)}/${escape(value_list.date_of_death_month)} ${escape(value_list.date_last_updated)} ${escape(value_list.last_updated_by)} agency_id:${escape(value_list.agency_case_id)} rc_id:${escape(value_list.record_id)}</li>`);
+    }
 
-			el.innerHTML = html.join("");
+    el.innerHTML = html.join('');
 
-			el = document.getElementById('case_result_pagination');
-			html = [];
-			render_pagination(html, g_case_view_request);
-			el.innerHTML = html.join("");
-		
-		}
-	)
-};
+    el = document.getElementById('case_result_pagination');
+    html = [];
+    render_pagination(html, g_case_view_request);
+    el.innerHTML = html.join('');
+  });
+}
 
+function render_selected_case_list(p_result, p_answer_summary) {
+  //html.push("<li><input type='checkbox' /> select all</li>");
+  for (let i = 0; i < p_answer_summary.case_set.length; i++) {
+    let item_id = p_answer_summary.case_set[i];
+    let value_list = selected_dictionary[item_id];
 
-function render_selected_case_list(p_result, p_answer_summary)
-{
-	//html.push("<li><input type='checkbox' /> select all</li>");
-	for(let i = 0; i < p_answer_summary.case_set.length; i++)
-	{
-		let item_id = p_answer_summary.case_set[i];
-		let value_list = selected_dictionary[item_id];
+    // Items generated after user ADDS applied filters
+    //html.push(`<li class="baz"><input value=${item_id} type="checkbox" onclick="result_checkbox_click(this)" checked="true" /> ${value_list.jurisdiction_id} ${value_list.last_name},${value_list.first_name} ${value_list.date_of_death_year}/${value_list.date_of_death_month} ${value_list.date_last_updated} ${value_list.last_updated_by} agency_id:${value_list.agency_case_id} rc_id:${value_list.record_id}</li>`);
 
-		// Items generated after user ADDS applied filters
-		//html.push(`<li class="baz"><input value=${item_id} type="checkbox" onclick="result_checkbox_click(this)" checked="true" /> ${value_list.jurisdiction_id} ${value_list.last_name},${value_list.first_name} ${value_list.date_of_death_year}/${value_list.date_of_death_month} ${value_list.date_last_updated} ${value_list.last_updated_by} agency_id:${value_list.agency_case_id} rc_id:${value_list.record_id}</li>`);
+    let checked = '';
+    let index = p_answer_summary.case_set.indexOf(item_id);
 
-		let checked = "";
-		let index = p_answer_summary.case_set.indexOf(item_id);
+    if (index > -1) {
+      checked = 'checked=true';
+    }
 
-		if(index > -1)
-		{
-			checked = "checked=true"
-		}
-
-		// Items generated after user applies filters
-		p_result.push(`
+    // Items generated after user applies filters
+    p_result.push(`
 			<tr class="tr font-weight-normal">
 				<td class="td" data-type="date_created" width="38" align="center">
 					<input id=${escape(item_id)}
@@ -852,116 +901,158 @@ function render_selected_case_list(p_result, p_answer_summary)
 					<label for="" class="sr-only">${escape(item_id)}</label>
 				</td>
 				<td class="td" data-type="date_last_updated">
-					${escape(value_list.date_last_updated).replace(/%20/g," ").replace(/%3A/g,"-")} <br/> ${escape(value_list.last_updated_by)}
+					${escape(value_list.date_last_updated)
+            .replace(/%20/g, ' ')
+            .replace(/%3A/g, '-')} <br/> ${escape(value_list.last_updated_by)}
 				</td>
 				<td class="td" data-type="jurisdiction_id">
-					${escape(value_list.last_name).replace(/%20/g," ").replace(/%3A/g,"-")}, ${escape(value_list.first_name).replace(/%20/g," ").replace(/%3A/g,"-")} ${escape(value_list.middle_name).replace(/%20/g," ").replace(/%3A/g,"-")} [${escape(value_list.jurisdiction_id)}]  
+					${escape(value_list.last_name)
+            .replace(/%20/g, ' ')
+            .replace(/%3A/g, '-')}, ${escape(value_list.first_name)
+      .replace(/%20/g, ' ')
+      .replace(/%3A/g, '-')} ${escape(value_list.middle_name)
+      .replace(/%20/g, ' ')
+      .replace(/%3A/g, '-')} [${escape(value_list.jurisdiction_id)}]  
 				</td>
 				<td class="td" data-type="record_id">
-					${escape(value_list.record_id).replace(/%20/g," ").replace(/%3A/g,"-")}
+					${escape(value_list.record_id).replace(/%20/g, ' ').replace(/%3A/g, '-')}
 				</td>
 				<td class="td" data-type="date_of_death">
-				${(value_list.date_of_death_year != null)? escape(value_list.date_of_death_year): "" }-${(value_list.date_of_death_month != null)? escape(value_list.date_of_death_month) : ""}
+				${
+          value_list.date_of_death_year != null
+            ? escape(value_list.date_of_death_year)
+            : ''
+        }-${
+      value_list.date_of_death_month != null
+        ? escape(value_list.date_of_death_month)
+        : ''
+    }
 				</td>
 				<td class="td" data-type="committee_review_date">
-				${(value_list.committee_review_date!=null)? escape(value_list.committee_review_date): "N/A"}
+				${
+          value_list.committee_review_date != null
+            ? escape(value_list.committee_review_date)
+            : 'N/A'
+        }
 				</td>
 				<td class="td" data-type="agency_case_id">
-					${escape(value_list.agency_case_id).replace(/%20/g," ").replace(/%3A/g,"-")}
+					${escape(value_list.agency_case_id).replace(/%20/g, ' ').replace(/%3A/g, '-')}
 				</td>
 				<td class="td" data-type="date_last_updated">
-					${escape(value_list.date_last_updated).replace(/%20/g," ").replace(/%3A/g,"-")}<br/>
-					${escape(value_list.created_by).replace(/%20/g," ").replace(/%3A/g,"-")}
+					${escape(value_list.date_last_updated)
+            .replace(/%20/g, ' ')
+            .replace(/%3A/g, '-')}<br/>
+					${escape(value_list.created_by).replace(/%20/g, ' ').replace(/%3A/g, '-')}
 				</td>
 			</tr>
 		`);
-	}
+  }
 }
 
+function de_identified_search_click() {
+  g_filter.selected_form = document.getElementById(
+    'de_identify_form_filter'
+  ).value;
 
-function de_identified_search_click()
-{
-	g_filter.selected_form = document.getElementById("de_identify_form_filter").value;
+  let de_identify_search_result_list = document.getElementById(
+    'de_identify_search_result_list'
+  );
 
-	let de_identify_search_result_list = document.getElementById("de_identify_search_result_list");
+  let result = [];
+  render_de_identified_search_result(result, answer_summary, g_filter);
 
-	let result = [];
-	render_de_identified_search_result(result, answer_summary, g_filter);
-
-	de_identify_search_result_list.innerHTML = result.join("");
-	
+  de_identify_search_result_list.innerHTML = result.join('');
 }
 
-function render_de_identified_search_result(p_result, p_answer_summary, p_filter)
-{
-	// Add toLowerCase() method to help with case sensitivity
-	render_de_identified_search_result_item(p_result, g_metadata, "", p_filter.selected_form, p_filter.search_text.toLowerCase());
+function render_de_identified_search_result(
+  p_result,
+  p_answer_summary,
+  p_filter
+) {
+  // Add toLowerCase() method to help with case sensitivity
+  render_de_identified_search_result_item(
+    p_result,
+    g_metadata,
+    '',
+    p_filter.selected_form,
+    p_filter.search_text.toLowerCase()
+  );
 }
 
-function render_de_identified_search_result_item(p_result, p_metadata, p_path, p_selected_form, p_search_text)
-{
-	switch(p_metadata.type.toLowerCase())
-	{
-		case "form":
-			if(p_selected_form== null || p_selected_form=="")
-			{
-				for(let i = 0; i < p_metadata.children.length; i++)
-				{
-					let item = p_metadata.children[i];
-					render_de_identified_search_result_item(p_result, item, p_path + "/" + item.name, p_selected_form, p_search_text);
-				}
-			}
-			else
-			{
-				if(p_metadata.name.toLowerCase() == p_selected_form.toLowerCase())
-				{
-					for(let i = 0; i < p_metadata.children.length; i++)
-					{
-						let item = p_metadata.children[i];
-						render_de_identified_search_result_item(p_result, item, p_path + "/" + item.name, p_selected_form, p_search_text);
-					}
-				}
-			}
-			break;
+function render_de_identified_search_result_item(
+  p_result,
+  p_metadata,
+  p_path,
+  p_selected_form,
+  p_search_text
+) {
+  switch (p_metadata.type.toLowerCase()) {
+    case 'form':
+      if (p_selected_form == null || p_selected_form == '') {
+        for (let i = 0; i < p_metadata.children.length; i++) {
+          let item = p_metadata.children[i];
+          render_de_identified_search_result_item(
+            p_result,
+            item,
+            p_path + '/' + item.name,
+            p_selected_form,
+            p_search_text
+          );
+        }
+      } else {
+        if (p_metadata.name.toLowerCase() == p_selected_form.toLowerCase()) {
+          for (let i = 0; i < p_metadata.children.length; i++) {
+            let item = p_metadata.children[i];
+            render_de_identified_search_result_item(
+              p_result,
+              item,
+              p_path + '/' + item.name,
+              p_selected_form,
+              p_search_text
+            );
+          }
+        }
+      }
+      break;
 
-		case "app":
-		case "group":
-		case "grid":
-			for(let i = 0; i < p_metadata.children.length; i++)
-			{
-				let item = p_metadata.children[i];
-				render_de_identified_search_result_item(p_result, item, p_path + "/" + item.name, p_selected_form, p_search_text);
-			}
-			break;
+    case 'app':
+    case 'group':
+    case 'grid':
+      for (let i = 0; i < p_metadata.children.length; i++) {
+        let item = p_metadata.children[i];
+        render_de_identified_search_result_item(
+          p_result,
+          item,
+          p_path + '/' + item.name,
+          p_selected_form,
+          p_search_text
+        );
+      }
+      break;
 
-		default:
-			if(p_search_text != null && p_search_text !="")
-			{
-				if
-				(
-					!(
-						p_metadata.name.indexOf(p_search_text) > -1 ||
-						p_metadata.prompt.indexOf(p_search_text) > -1 
-					)
-				
-				)
-				{
-					return;
-				}
-			}
+    default:
+      if (p_search_text != null && p_search_text != '') {
+        if (
+          !(
+            p_metadata.name.indexOf(p_search_text) > -1 ||
+            p_metadata.prompt.indexOf(p_search_text) > -1
+          )
+        ) {
+          return;
+        }
+      }
 
-		//let item_id = (p_path + "-" + p_metadata.name).replace(/\//g,"-");
-		let item_id = (p_path).replace(/\//g,"-");
-		selected_metadata_dictionary[item_id] = p_metadata;
-		let checked = "";
-		let index = answer_summary.de_identified_field_set.indexOf(item_id);
+      //let item_id = (p_path + "-" + p_metadata.name).replace(/\//g,"-");
+      let item_id = p_path.replace(/\//g, '-');
+      selected_metadata_dictionary[item_id] = p_metadata;
+      let checked = '';
+      let index = answer_summary.de_identified_field_set.indexOf(item_id);
 
-		if(index > -1)
-		{
-			checked = "checked=true"
-		}
+      if (index > -1) {
+        checked = 'checked=true';
+      }
 
-		p_result.push(`
+      p_result.push(`
 			<tr class="tr">
 				<td class="td text-center" width="38">
 					<input id="unique_id_1" type="checkbox" onclick="de_identified_result_checkbox_click(this)" value="${item_id}"  ${checked} />
@@ -1000,122 +1091,104 @@ function render_de_identified_search_result_item(p_result, p_metadata, p_path, p
 				</td>
 			</tr>
 		`);
-		break;
-	}
+      break;
+  }
 }
 
-function render_standard_de_identify_fields(p_paths)
-{
-	let result = '';
+function render_standard_de_identify_fields(p_paths) {
+  let result = '';
 
-	for (let i = 0; i < p_paths.paths.length; i++) {
-		let path = p_paths.paths[i];
-		result += `
+  for (let i = 0; i < p_paths.paths.length; i++) {
+    let path = p_paths.paths[i];
+    result += `
 			<tr class="tr">
 				<td class="td">
 					<strong>Path:</strong> ${path}
 				</td>
 			</tr>
 		`;
-	}
+  }
 
-	return result;
+  return result;
 }
 
-function render_de_identify_form_filter(p_filter)
-{
-	let result = [];
+function render_de_identify_form_filter(p_filter) {
+  let result = [];
 
-	result.push(`<option value="">(Any Form)</option>`)
+  result.push(`<option value="">(Any Form)</option>`);
 
-	for(let i = 0; i < g_metadata.children.length; i++)
-	{
-		let item = g_metadata.children[i];
+  for (let i = 0; i < g_metadata.children.length; i++) {
+    let item = g_metadata.children[i];
 
-		if(item.type.toLowerCase() == "form")
-		{
+    if (item.type.toLowerCase() == 'form') {
+      if (p_filter.selected_form == item.name) {
+        result.push(
+          `<option value="${item.name}" selected>${item.prompt}</option>`
+        );
+      } else {
+        result.push(`<option value="${item.name}">${item.prompt}</option>`);
+      }
+    }
+  }
 
-			if(p_filter.selected_form == item.name)
-			{
-				result.push(`<option value="${item.name}" selected>${item.prompt}</option>`)
-			}
-			else
-			{
-				result.push(`<option value="${item.name}">${item.prompt}</option>`)
-			}
-			
-		}
-		
-	}
-
-	return result.join("");
+  return result.join('');
 }
 
+function de_identified_result_checkbox_click(p_checkbox) {
+  let value = p_checkbox.value;
 
-function de_identified_result_checkbox_click(p_checkbox)
-{
-	let value = p_checkbox.value;
+  if (p_checkbox.checked) {
+    if (answer_summary.de_identified_field_set.indexOf(value) < 0) {
+      answer_summary.de_identified_field_set.push(value);
+    }
+  } else {
+    let index = answer_summary.de_identified_field_set.indexOf(value);
 
-	if(p_checkbox.checked)
-	{
+    if (index > -1) {
+      answer_summary.de_identified_field_set.splice(index, 1);
+    }
+  }
 
-		if(answer_summary.de_identified_field_set.indexOf(value) < 0)
-		{
-			answer_summary.de_identified_field_set.push(value)
-		}
-	}
-	else
-	{
-		let index = answer_summary.de_identified_field_set.indexOf(value);
+  let el = document.getElementById('selected_de_identified_field_list');
+  let result = [];
 
-		if(index > -1)
-		{
-			answer_summary.de_identified_field_set.splice(index,1)
-		}
-	}
+  render_selected_de_identified_list(result, answer_summary);
 
-	let el = document.getElementById('selected_de_identified_field_list');
-	let result = [];
+  el.innerHTML = result.join('');
 
-	render_selected_de_identified_list(result, answer_summary);
+  let de_identify_search_result_list = document.getElementById(
+    'de_identify_search_result_list'
+  );
 
-	el.innerHTML = result.join("");
+  render_de_identified_search_result(result, answer_summary, g_filter);
 
-	let de_identify_search_result_list = document.getElementById("de_identify_search_result_list");
+  de_identify_search_result_list.innerHTML = result.join('');
 
-	render_de_identified_search_result(result, answer_summary, g_filter);
+  el = document.getElementById('de_identified_count');
+  el.innerHTML = `Fields that have been de-identified (${answer_summary.de_identified_field_set.length})`;
 
-	de_identify_search_result_list.innerHTML = result.join("");
-
-	el = document.getElementById('de_identified_count');
-	el.innerHTML = `Fields that have been de-identified (${answer_summary.de_identified_field_set.length})`;
-
-	renderSummarySection(p_checkbox);
+  renderSummarySection(p_checkbox);
 }
 
+function render_selected_de_identified_list(p_result, p_answer_summary) {
+  //let el = document.getElementById('selected_de_identified_field_list');
 
-function render_selected_de_identified_list(p_result, p_answer_summary)
-{
-	//let el = document.getElementById('selected_de_identified_field_list');
+  //html.push("<li><input type='checkbox' /> select all</li>");
+  for (let i = 0; i < p_answer_summary.de_identified_field_set.length; i++) {
+    let item_id = p_answer_summary.de_identified_field_set[i];
+    let value_list = selected_metadata_dictionary[item_id];
 
-	//html.push("<li><input type='checkbox' /> select all</li>");
-	for(let i = 0; i < p_answer_summary.de_identified_field_set.length; i++)
-	{
-		let item_id = p_answer_summary.de_identified_field_set[i];
-		let value_list = selected_metadata_dictionary[item_id];
+    // Items generated after user ADDS applied filters
+    //html.push(`<li class="baz"><input value=${item_id} type="checkbox" onclick="result_checkbox_click(this)" checked="true" /> ${value_list.jurisdiction_id} ${value_list.last_name},${value_list.first_name} ${value_list.date_of_death_year}/${value_list.date_of_death_month} ${value_list.date_last_updated} ${value_list.last_updated_by} agency_id:${value_list.agency_case_id} rc_id:${value_list.record_id}</li>`);
 
-		// Items generated after user ADDS applied filters
-		//html.push(`<li class="baz"><input value=${item_id} type="checkbox" onclick="result_checkbox_click(this)" checked="true" /> ${value_list.jurisdiction_id} ${value_list.last_name},${value_list.first_name} ${value_list.date_of_death_year}/${value_list.date_of_death_month} ${value_list.date_last_updated} ${value_list.last_updated_by} agency_id:${value_list.agency_case_id} rc_id:${value_list.record_id}</li>`);
+    let checked = '';
+    let index = p_answer_summary.de_identified_field_set.indexOf(item_id);
 
-		let checked = "";
-		let index = p_answer_summary.de_identified_field_set.indexOf(item_id);
+    if (index > -1) {
+      checked = 'checked=true';
+    }
 
-		if(index > -1)
-		{
-			checked = "checked=true"
-		}
-
-		p_result.push(`
+    p_result.push(`
 			<tr class="tr">
 				<td class="td text-center" width="38">
 					<input id="unique_id_1" type="checkbox" onclick="de_identified_result_checkbox_click(this)" value="${item_id}"  ${checked} />
@@ -1127,15 +1200,21 @@ function render_selected_de_identified_list(p_result, p_answer_summary)
 							<tr class="tr">
 								<th class="th" colspan="4" scope="colgroup">
 									<button class="anti-btn w-100 row no-gutters align-items-center justify-content-between"
-													data-prop="selected--${item_id.replace(/-/g,"/")}"
+													data-prop="selected--${item_id.replace(/-/g, '/')}"
 													onclick="handleElementDisplay(event, 'table-row', 'none')">
-										<span class="pointer-none"><strong>Path:</strong> ${item_id.replace(/-/g,"/")}</span>
+										<span class="pointer-none"><strong>Path:</strong> ${item_id.replace(
+                      /-/g,
+                      '/'
+                    )}</span>
 									</button>
 								</th>
 							</tr>
 						</thead>
 						<thead class="thead">
-							<tr class="tr bg-white" data-show="selected--${item_id.replace(/-/g,"/")}" style="display: none;">
+							<tr class="tr bg-white" data-show="selected--${item_id.replace(
+                /-/g,
+                '/'
+              )}" style="display: none;">
 								<th class="th" scope="col">Name</th>
 								<th class="th" scope="col">Type</th>
 								<th class="th" scope="col">Prompt</th>
@@ -1143,10 +1222,13 @@ function render_selected_de_identified_list(p_result, p_answer_summary)
 							</tr>
 						</thead>
 						<tbody class="tbody">
-							<tr class="tr" data-show="selected--${item_id.replace(/-/g,"/")}" style="display: none;">
-								<td class="td">${(value_list != null) ? value_list.name : '' }</td>
-								<td class="td">${(value_list != null) ? value_list.type : ''}</td>
-								<td class="td">${(value_list != null) ? value_list.prompt : ''}</td>
+							<tr class="tr" data-show="selected--${item_id.replace(
+                /-/g,
+                '/'
+              )}" style="display: none;">
+								<td class="td">${value_list != null ? value_list.name : ''}</td>
+								<td class="td">${value_list != null ? value_list.type : ''}</td>
+								<td class="td">${value_list != null ? value_list.prompt : ''}</td>
 								<td class="td"></td>
 							</tr>
 						</tbody>
@@ -1154,246 +1236,258 @@ function render_selected_de_identified_list(p_result, p_answer_summary)
 				</td>
 			</tr>
 		`);
-	}
+  }
 
-	//el.innerHTML = html.join("");
+  //el.innerHTML = html.join("");
 }
 
+function render_sort_by_include_in_export(p_case_view_request) {
+  // Not sure how to retrieve these keys so creating them statically
+  // TODO: Get with James to make this more dynamic
+  const export_include_list = [
+    'first_name',
+    'middle_name',
+    'last_name',
+    'date_of_death_year',
+    'date_of_death_month',
+    'date_created',
+    'created_by',
+    'date_last_updated',
+    'last_updated_by',
+    'record_id',
+    'agency_case_id',
+    'date_of_committee_review',
+    'jurisdiction_id',
+  ];
+  // Empty string to push dynamically created options into
+  const result = [];
 
-function render_sort_by_include_in_export(p_case_view_request)
-{
-	// Not sure how to retrieve these keys so creating them statically
-	// TODO: Get with James to make this more dynamic
-	const export_include_list = [
-		'first_name',
-		'middle_name',
-		'last_name',
-		'date_of_death_year',
-		'date_of_death_month',
-		'date_created',
-		'created_by',
-		'date_last_updated',
-		'last_updated_by',
-		'record_id',
-		'agency_case_id',
-		'date_of_committee_review',
-		'jurisdiction_id'
-	];
-	// Empty string to push dynamically created options into
-	const result = [];
+  // <option value="date_created" selected="">date_created</option><option value="jurisdiction_id">jurisdiction_id</option><option value="last_name">last_name</option><option value="first_name">first_name</option><option value="middle_name">middle_name</option><option value="state_of_death">state_of_death</option><option value="record_id">record_id</option><option value="year_of_death">year_of_death</option><option value="month_of_death">month_of_death</option><option value="committee_review_date">committee_review_date</option><option value="agency_case_id">agency_case_id</option><option value="created_by">created_by</option><option value="last_updated_by">last_updated_by</option><option value="date_last_updated">date_last_updated</option>
 
-	// <option value="date_created" selected="">date_created</option><option value="jurisdiction_id">jurisdiction_id</option><option value="last_name">last_name</option><option value="first_name">first_name</option><option value="middle_name">middle_name</option><option value="state_of_death">state_of_death</option><option value="record_id">record_id</option><option value="year_of_death">year_of_death</option><option value="month_of_death">month_of_death</option><option value="committee_review_date">committee_review_date</option><option value="agency_case_id">agency_case_id</option><option value="created_by">created_by</option><option value="last_updated_by">last_updated_by</option><option value="date_last_updated">date_last_updated</option>
+  // Using the trusty ole' .map method instead of for loop
+  export_include_list.map((item) => {
+    // Ternary: if sort = current item, add selected attr
+    // Also remove underscores then capitalize first letter in UI, but not value as that it important for sort
+    result.push(
+      `<option value="${item}" ${
+        item === p_case_view_request.sort ? 'selected' : ''
+      }>${capitalizeFirstLetter(item).replace(/_/g, ' ')}</option>`
+    );
+  });
 
-	// Using the trusty ole' .map method instead of for loop
-	export_include_list.map((item) => {
-		// Ternary: if sort = current item, add selected attr
-		// Also remove underscores then capitalize first letter in UI, but not value as that it important for sort
-		result.push(`<option value="${item}" ${ item === p_case_view_request.sort ? 'selected' : ''}>${capitalizeFirstLetter(item).replace(/_/g, ' ')}</option>`)
-	});
-
-	return result.join(''); // .join('') removes trailing comma in array interation
+  return result.join(''); // .join('') removes trailing comma in array interation
 }
 
+function case_filter_type_click(p_value) {
+  answer_summary.case_filter_type = p_value.value.toLowerCase();
 
-function case_filter_type_click(p_value)
-{
+  var custom_case_filter = document.getElementById('custom_case_filter');
+  if (p_value.value.toLowerCase() == 'custom') {
+    custom_case_filter.style.display = 'block';
+  } else {
+    custom_case_filter.style.display = 'none';
+  }
 
-	answer_summary.case_filter_type = p_value.value.toLowerCase()
-
-	var custom_case_filter = document.getElementById("custom_case_filter");
-	if(p_value.value.toLowerCase() == "custom")
-	{
-		custom_case_filter.style.display = "block";
-	}
-	else
-	{
-		custom_case_filter.style.display = "none";
-	}
-
-	renderSummarySection(p_value)
+  renderSummarySection(p_value);
 }
 
+function de_identify_filter_type_click(p_value) {
+  var de_identify_filter_standard = document.getElementById(
+    'de_identify_filter_standard'
+  );
+  var de_identify_filter = document.getElementById('de_identify_filter');
 
-function de_identify_filter_type_click(p_value)
-{
-	var de_identify_filter_standard = document.getElementById("de_identify_filter_standard");
-	var de_identify_filter = document.getElementById("de_identify_filter");
-
-	/*
+  /*
 		setAnswerSummary(event).then(updateSummarySection(event)).then(handleElementDisplay(event, 'block'))
 	*/
 
-	// Making this a promise so I can return a 'then' method
-	return new Promise((resolve, reject) => {
-		if (true)
-		{
-			if (p_value.value.toLowerCase() == "standard") {
-				de_identify_filter.style.display = "none";
-				de_identify_filter_standard.style.display = "block";
-			} else if (p_value.value.toLowerCase() == "custom") {
-				de_identify_filter_standard.style.display = "none";
-				de_identify_filter.style.display = "block";
-			} else {
-				de_identify_filter_standard.style.display = "none";
-				de_identify_filter.style.display = "none";
-			}
-			answer_summary.de_identified_selection_type = p_value.value.toLowerCase()
-			resolve();
-		}
-		else
-		{
-			reject();
-		}
+  // Making this a promise so I can return a 'then' method
+  return new Promise((resolve, reject) => {
+    if (true) {
+      if (p_value.value.toLowerCase() == 'standard') {
+        de_identify_filter.style.display = 'none';
+        de_identify_filter_standard.style.display = 'block';
+      } else if (p_value.value.toLowerCase() == 'custom') {
+        de_identify_filter_standard.style.display = 'none';
+        de_identify_filter.style.display = 'block';
+      } else {
+        de_identify_filter_standard.style.display = 'none';
+        de_identify_filter.style.display = 'none';
+      }
+      answer_summary.de_identified_selection_type = p_value.value.toLowerCase();
+      resolve();
+    } else {
+      reject();
+    }
 
-		// if (!isNullOrUndefined(de_identify_filter)) {
-		// 	if(p_value.value.toLowerCase() == "custom")
-		// 	{
-		// 		de_identify_filter.style.display = "block";
-		// 	}
-		// 	else
-		// 	{
-		// 		de_identify_filter.style.display = "none";
-		// 	}
+    // if (!isNullOrUndefined(de_identify_filter)) {
+    // 	if(p_value.value.toLowerCase() == "custom")
+    // 	{
+    // 		de_identify_filter.style.display = "block";
+    // 	}
+    // 	else
+    // 	{
+    // 		de_identify_filter.style.display = "none";
+    // 	}
 
-		// 	answer_summary.de_identified_selection_type = p_value.value.toLowerCase()
+    // 	answer_summary.de_identified_selection_type = p_value.value.toLowerCase()
 
-		// 	resolve();
-		// }
-		// else
-		// {
-		// 	reject();
-		// }
-	})
+    // 	resolve();
+    // }
+    // else
+    // {
+    // 	reject();
+    // }
+  });
 }
 
-
-function de_identify_search_text_change(p_value)
-{
-	g_filter.search_text = p_value;
+function de_identify_search_text_change(p_value) {
+  g_filter.search_text = p_value;
 }
 
-
-function filter_serach_text_change(p_value)
-{
-	g_case_view_request.search_key = p_value;
+function filter_serach_text_change(p_value) {
+  g_case_view_request.search_key = p_value;
 }
 
-
-function de_identify_standard_fields_change(p_value)
-{
-	answer_summary.is_de_identify_standard_fields = p_value;
+function de_identify_standard_fields_change(p_value) {
+  answer_summary.is_de_identify_standard_fields = p_value;
 }
 
-
-function render_pagination(p_result, p_case_view_request)
-{
-    //p_result.push("<div id='case_result_pagination' class='table-pagination row align-items-center no-gutters'>");
-        p_result.push("<div class='col'>");
-            p_result.push("<div class='row no-gutters'>");
-                p_result.push("<p class='mb-0'>Total Records: ");
-                    p_result.push("<strong>" + p_case_view_request.total_rows + "</strong>");
-                p_result.push("</p>");
-                p_result.push("<p class='mb-0 ml-2 mr-2'>|</p>");
-                p_result.push("<p class='mb-0'>Viewing Page(s): ");
-                    p_result.push("<strong>" + p_case_view_request.page + "</strong> ");
-                    p_result.push("of ");
-                    p_result.push("<strong>" + Math.ceil(p_case_view_request.total_rows / p_case_view_request.take) + "</strong>");
-                p_result.push("</p>");
-            p_result.push("</div>");
-        p_result.push("</div>");
-        p_result.push("<div class='col row no-gutters align-items-center justify-content-end'>");
-            p_result.push("<p class='mb-0'>Select by page:</p>");
-            for(let current_page = 1; (current_page - 1) * p_case_view_request.take < p_case_view_request.total_rows; current_page++)
-            {
-                p_result.push("<button type='button' class='table-btn-link btn btn-link' alt='select page " + current_page + "' onclick='g_ui.case_view_request.page=");
-                    p_result.push(current_page);
-                    p_result.push(";get_case_set();'>");
-                    p_result.push(current_page);
-                p_result.push("</button>");
-            }
-        p_result.push("</div>");
-    //p_result.push("</div>");
+function render_pagination(p_result, p_case_view_request) {
+  //p_result.push("<div id='case_result_pagination' class='table-pagination row align-items-center no-gutters'>");
+  p_result.push("<div class='col'>");
+  p_result.push("<div class='row no-gutters'>");
+  p_result.push("<p class='mb-0'>Total Records: ");
+  p_result.push('<strong>' + p_case_view_request.total_rows + '</strong>');
+  p_result.push('</p>');
+  p_result.push("<p class='mb-0 ml-2 mr-2'>|</p>");
+  p_result.push("<p class='mb-0'>Viewing Page(s): ");
+  p_result.push('<strong>' + p_case_view_request.page + '</strong> ');
+  p_result.push('of ');
+  p_result.push(
+    '<strong>' +
+      Math.ceil(p_case_view_request.total_rows / p_case_view_request.take) +
+      '</strong>'
+  );
+  p_result.push('</p>');
+  p_result.push('</div>');
+  p_result.push('</div>');
+  p_result.push(
+    "<div class='col row no-gutters align-items-center justify-content-end'>"
+  );
+  p_result.push("<p class='mb-0'>Select by page:</p>");
+  for (
+    let current_page = 1;
+    (current_page - 1) * p_case_view_request.take <
+    p_case_view_request.total_rows;
+    current_page++
+  ) {
+    p_result.push(
+      "<button type='button' class='table-btn-link btn btn-link' alt='select page " +
+        current_page +
+        "' onclick='g_ui.case_view_request.page="
+    );
+    p_result.push(current_page);
+    p_result.push(";get_case_set();'>");
+    p_result.push(current_page);
+    p_result.push('</button>');
+  }
+  p_result.push('</div>');
+  //p_result.push("</div>");
 }
 
+function render_summary_de_identified_fields(p_answer_summary) {
+  let result = [];
 
-function render_summary_de_identified_fields(p_answer_summary)
-{
-	let result = [];
+  switch (p_answer_summary.de_identified_selection_type.toLowerCase()) {
+    case 'none':
+      break;
+    case 'standard':
+      result.push("<table class='bg-white mt-1 w-100'>");
 
-	switch(p_answer_summary.de_identified_selection_type.toLowerCase())
-	{
-		case "none":
-
-			break;
-		case "standard":
-			result.push("<table class='bg-white mt-1 w-100'>")
-
-			for (let i = 0; i < g_standard_de_identified_list.paths.length; i++) 
-			{
-				let path = g_standard_de_identified_list.paths[i];
-				result.push(`
+      for (let i = 0; i < g_standard_de_identified_list.paths.length; i++) {
+        let path = g_standard_de_identified_list.paths[i];
+        result.push(`
 					<tr class="tr">
 						<td class="td">
 							<strong>Path:</strong> ${path}
 						</td>
 					</tr>
 				`);
-			}
-			result.push("</table>");
-			break;
+      }
+      result.push('</table>');
+      break;
 
-		case "custom":
-				result.push("<table>");
-	
-				for (let i = 0; i < p_answer_summary.de_identified_field_set.length; i++) 
-				{
-					let path = p_answer_summary.de_identified_field_set[i];
-					result.push(`
+    case 'custom':
+      result.push('<table>');
+
+      for (
+        let i = 0;
+        i < p_answer_summary.de_identified_field_set.length;
+        i++
+      ) {
+        let path = p_answer_summary.de_identified_field_set[i];
+        result.push(`
 						<tr class="tr">
 							<td class="td">
 								<strong>Path:</strong> ${path}
 							</td>
 						</tr>
 					`);
-				}
-				result.push("</table>")
-				break;
-	}
-	
-	return result.join("");
+      }
+      result.push('</table>');
+      break;
+  }
+
+  return result.join('');
 }
 
+function render_summary_of_selected_cases(p_answer_summary) {
+  let result = [];
 
-function render_summary_of_selected_cases(p_answer_summary)
-{
-	let result = [];
+  switch (p_answer_summary.case_filter_type.toLowerCase()) {
+    case 'all':
+      break;
 
-	switch(p_answer_summary.case_filter_type.toLowerCase())
-	{
-		case "all":
-			break;
+    case 'custom':
+      result.push('<table>');
 
-		case "custom":
-				result.push("<table>");
-	
-				for (let i = 0; i < p_answer_summary.case_set.length; i++) 
-				{
+      for (let i = 0; i < p_answer_summary.case_set.length; i++) {
+        let value_list = selected_dictionary[p_answer_summary.case_set[i]];
+        //let path = p_answer_summary.case_set[i];
 
-					let value_list = selected_dictionary[p_answer_summary.case_set[i]];
-					//let path = p_answer_summary.case_set[i];
-
-					let text_value = escape(value_list.date_last_updated).replace(/%20/g," ").replace(/%3A/g,"-") + "<br/>" + escape(value_list.last_updated_by) + " " + escape(value_list.last_name).replace(/%20/g," ").replace(/%3A/g,"-") + ", " + escape(value_list.first_name).replace(/%20/g," ").replace(/%3A/g,"-") + " " + escape(value_list.middle_name).replace(/%20/g," ").replace(/%3A/g,"-") + " [" + escape(value_list.jurisdiction_id) + "]";
-					result.push(`
+        let text_value =
+          escape(value_list.date_last_updated)
+            .replace(/%20/g, ' ')
+            .replace(/%3A/g, '-') +
+          '<br/>' +
+          escape(value_list.last_updated_by) +
+          ' ' +
+          escape(value_list.last_name)
+            .replace(/%20/g, ' ')
+            .replace(/%3A/g, '-') +
+          ', ' +
+          escape(value_list.first_name)
+            .replace(/%20/g, ' ')
+            .replace(/%3A/g, '-') +
+          ' ' +
+          escape(value_list.middle_name)
+            .replace(/%20/g, ' ')
+            .replace(/%3A/g, '-') +
+          ' [' +
+          escape(value_list.jurisdiction_id) +
+          ']';
+        result.push(`
 						<tr class="tr">
 							<td class="td">
 							${text_value}
 							</td>
 						</tr>
 					`);
-				}
-				result.push("</table>")
-				break;
-	}
-	
-	return result.join("");
+      }
+      result.push('</table>');
+      break;
+  }
+
+  return result.join('');
 }

--- a/source-code/mmria/mmria-server/wwwroot/scripts/export-queue/export_queue_renderer.js
+++ b/source-code/mmria/mmria-server/wwwroot/scripts/export-queue/export_queue_renderer.js
@@ -14,20 +14,6 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter) {
     p_answer_summary
   );
 
-  let selected_case_list = [];
-  render_selected_case_list(selected_case_list, p_answer_summary);
-
-  let pagination_html = [];
-  render_pagination(pagination_html, g_case_view_request);
-
-  let filter_decending = '';
-
-  if (g_case_view_request.descending) {
-    filter_decending = 'checked=true';
-  }
-
-  // console.log(g_case_view_request);
-
   result.push(`
 		<div class="row">
 			<div class="col">
@@ -225,167 +211,12 @@ function export_queue_render(p_queue_data, p_answer_summary, p_filter) {
 						</div>
 					</li>
 
-					<li class="mb-4">
-						<p class="mb-3">Please select which cases you want to include in the export?</p>
-						<label for="case_filter_type_all" class="font-weight-normal mr-2">
-							<input id="case_filter_type_all"
-										 type="radio"
-										 name="case_filter_type"
-										 value="all"
-										 data-prop="case_filter_type"
-										 ${p_answer_summary['case_filter_type'] == 'all' ? 'checked=true' : ''}
-										 onclick="case_filter_type_click(this)" /> All
-						</label>
-						<label for="case_filter_type_custom" class="font-weight-normal">
-							<input id="case_filter_type_custom"
-										 type="radio"
-										 name="case_filter_type"
-										 value="custom"
-										 data-prop="case_filter_type"
-										 ${p_answer_summary['case_filter_type'] == 'custom' ? 'checked=true' : ''}
-										 onclick="case_filter_type_click(this)" /> Custom
-						</label>
-						<ul class="font-weight-bold list-unstyled mt-3" id="custom_case_filter" style="display:${
-              p_answer_summary['case_filter_type'] == 'custom'
-                ? 'block'
-                : 'none'
-            }">
-							<li class="mb-4" >
-								<div class="form-inline mb-2">
-									<label for="filter_search_text" class="font-weight-normal mr-2">Search for:</label>
-									<input type="text"
-												 class="form-control mr-2"
-												 id="filter_search_text"
-												 value=""
-												 onchange="filter_serach_text_change(this.value)">
-									<button type="button" class="btn btn-secondary" alt="search" onclick="init_inline_loader(apply_filter_button_click)">Apply Filters</button>
-									<span class="spinner-container spinner-inline ml-2"><span class="spinner-body text-primary"><span class="spinner"></span></span></span>
-								</div>
-
-								<div class="form-inline mb-2">
-									<label for="filter_sort_by" class="font-weight-normal mr-2">Sort by:</label>
-									<select id="filter_sort_by" class="custom-select" >
-										${render_sort_by_include_in_export(g_case_view_request)}
-									</select>
-								</div>
-
-								<div class="form-inline mb-2">
-									<label for="filter_records_perPage" class="font-weight-normal mr-2">Records per page:</label>
-									<select id="filter_records_perPage" class="custom-select" ><option>25</option><option>50</option><option selected="">100</option><option>250</option><option>500</option></select>
-								</div>
-
-								<div class="form-inline mb-2">
-									<label for="filter_decending" class="font-weight-normal mr-2">Descending order:</label>
-									<input id="filter_decending" type="checkbox" ${filter_decending}/>
-								</div>
-							</li>
-
-							<li class="mb-3" style="overflow:hidden; overflow-y: auto; height: 360px; border: 1px solid #ced4da;">
-								<div id='case_result_pagination' class='table-pagination row align-items-center no-gutters pt-1 pb-1 pl-2 pr-2'>
-									${pagination_html.join('')}
-								</div>
-								<table class="table rounded-0 m-0">
-									<thead class="thead">
-										<tr class="tr bg-tertiary">
-											<th class="th" colspan="14" scope="colgroup">
-												<span class="row no-gutters justify-content-between">
-													<span>Filtered Cases</span>
-													<!--button class="anti-btn" onclick="fooBarSelectAll()">Select All</button-->
-												</span>
-											</th>
-										</tr>
-									</thead>
-									<thead class="thead">
-										<tr class="tr">
-											<th class="th" width="38" scope="col"></th>
-											<th class="th" scope="col">Date last updated <br/>Last updated by</th>
-											<th class="th" scope="col">Name [Jurisdiction ID]</th>
-											<th class="th" scope="col">Record ID</th>
-											<th class="th" scope="col">Date of death</th>
-											<th class="th" scope="col">Committee review date</th>
-											<th class="th" scope="col">Agency case ID</th>
-											<th class="th" scope="col">Date created<br/>Created by</th>
-										</tr>
-									</thead>
-									<tbody id="search_result_list" class="tbody">
-										<!-- items get dynamically generated -->
-									</tbody>
-								</table>
-							</li>
-
-							<li class="" style="overflow:hidden; overflow-y: auto; height: 360px; border: 1px solid #ced4da;">
-								<table class="table rounded-0 mb-0">
-									<thead class="thead">
-										<tr class="tr bg-tertiary">
-											<th class="th" colspan="14" scope="colgroup">
-												<span class="row no-gutters justify-content-between">
-													<span id="exported_cases_count">Cases to be included in export (${
-                            p_answer_summary.case_set.length
-                          }):</span>
-													<!--button class="anti-btn" onclick="fooBarSelectAll()">Deselect All</button-->
-												</span>
-											</th>
-										</tr>
-									</thead>
-									<thead class="thead">
-										<tr class="tr">
-											<th class="th" width="38" scope="col"></th>
-											<th class="th" scope="col">Date last updated <br/>Last updated by</th>
-											<th class="th" scope="col">Name [Jurisdiction ID]</th>
-											<th class="th" scope="col">Record ID</th>
-											<th class="th" scope="col">Date of death</th>
-											<th class="th" scope="col">Committee review date</th>
-											<th class="th" scope="col">Agency case ID</th>
-											<th class="th" scope="col">Date created<br/>Created by</th>
-										</tr>
-									</thead>
-									<tbody id="selected_case_list" class="tbody">
-										${selected_case_list.join('')}
-									</tbody>
-								</table>
-							</li>
-						</ul>
+					<li class="mb-4" id="react-content">
 					</li>
 				</ol>
 			</div>
 		</div>
 	`);
-  /*
-	result.push("<hr/>");
-
-	result.push('<p>Click on Export Core Data to CSV format to produce a zip file that contains your core data export plus a data dictionary. The zip file will be downloaded directly to the “Downloads” folder in the local environment of your computer.</p>');
-	result.push('<p class="mb-0"><strong>Contains 2 Files:</strong></p>');
-	result.push('<ul>');
-		result.push('<li>core_export.csv</li>');
-		result.push('<li>data-dictionary.csv</li>');
-	result.push('</ul>');
-	result.push('<button type="button" class="btn btn-secondary mb-2" onclick="add_new_core_export_item()">Export Core Data to CSV format</button>');
-	result.push('<p>Details of the data dictionary format can be found here: <a target="_data_dictionary" href="/data-dictionary">data-dictionary-format</a></p>');
-	
-	result.push('<hr />');
-
-
-	
-
-	result.push('<p>Click on Export All Data to CSV format to produce a zip file that contains 59 case data files plus a data dictionary. The zip file will be downloaded directly to the “Downloads” folder in the local environment of your computer.</p>');
-	result.push('<p class="mb-0"><strong>Contains a total of 60 files:</strong></p>');
-	result.push('<ul>');
-		result.push('<li>59 *.csv</li>');
-		result.push('<li>data-dictionary.csv</li>');
-	result.push('</ul>');
-	result.push('<button type="button" class="btn btn-secondary mb-2" onclick="add_new_all_export_item()">Export All Data to  CSV format</button>');
-	result.push('<p>Details of the data dictionary format can be found here: <a target="_data_dictionary" href="/data-dictionary">data-dictionary-format</a></p>');
-
-*/
-
-  // result.push("<ul>");
-  // 	result.push("<li><input type='button' value='Export Core Data to CSV format.' onclick='add_new_core_export_item()'/>");
-  // 	result.push("<br/>Click on Export Core Data to CSV format to produce a zip file that contains your core data export plus a data dictionary. The zip file will be downloaded directly to the “Downloads” folder in the local environment of your computer.<br/>Contains 2 Files<ul><li>core_export.csv</li><li>data-dictionary.csv <p>Details of the data dictionary format can be found here: <a target='_data_dictionary' href='/data-dictionary'>data-dictionary-format</a></p></li></ul></li>");
-  // 	result.push("<li><input type='button' value='Export All Data to  CSV format.' onclick='add_new_all_export_item()'/>");
-  // 	result.push("<br/>Click on Export All Data to CSV format to produce a zip file that contains 59 case data files plus a data dictionary. The zip file will be downloaded directly to the “Downloads” folder in the local environment of your computer.<br/>Contains a total of 60 files:<ul><li>59 *.csv</li><li>data-dictionary.csv <p>Details of the data dictionary format can be found here: <a target='_data_dictionary' href='/data-dictionary'>data-dictionary-format</a></p></li></ul></li>");
-  // 	//result.push("<li><input type='button' value='Export All Data to  Deidentified CDC CSV format.' onclick='add_new_cdc_export_item()'/></li>");
-  // 	//result.push("<li><input type='button' value='All Data to MMRIA JSON format.' onclick='add_new_json_export_item()'/></li>");
-  // result.push("</ul>");
 
   result.push(`
 		<div class="row">
@@ -550,7 +381,7 @@ function export_queue_comfirm_render(p_answer_summary) {
 						</div>
 					</li>
 				</ul>
-			</div>
+      </div>
 			<div class="card-footer bg-gray-l3">
 				<button class="btn btn-primary btn-lg w-100" onclick="add_new_all_export_item()">Confirm & Start Export</button>
 			</div>
@@ -632,17 +463,6 @@ function handleElementDisplay(event, str) {
       reject('Target(s) do not exist');
     }
   });
-
-  // tars.forEach((el) =>
-  // {
-  // 	if (el.style.display == 'none') {
-  // 		el.style.display == str;
-  // 		console.log('a');
-  // 	} else {
-  // 		el.style.display == 'none';
-  // 		console.log('b');
-  // 	}
-  // });
 }
 
 // Class to dynamically create a new 'numeric' dropdown
@@ -679,273 +499,6 @@ class NumericDropdown {
       this.opts += '</option>';
     }
     return this.opts;
-  }
-}
-
-function apply_filter_button_click() {
-  var filter_search_text = document.getElementById('filter_search_text');
-  var filter_sort_by = document.getElementById('filter_sort_by');
-  var filter_records_perPage = document.getElementById(
-    'filter_records_perPage'
-  );
-  var filter_decending = document.getElementById('filter_decending');
-
-  /*
-	g_case_view_request.total_rows = 0,
-	g_case_view_request.page = 1,
-	g_case_view_request.skip = 0,
-	*/
-
-  g_case_view_request.take = filter_records_perPage.value;
-  g_case_view_request.sort = filter_sort_by.value;
-  g_case_view_request.search_key = filter_search_text.value;
-  g_case_view_request.descending = filter_decending.checked;
-
-  get_case_set();
-}
-
-function result_checkbox_click(p_checkbox) {
-  let value = p_checkbox.value;
-
-  if (p_checkbox.checked) {
-    if (answer_summary.case_set.indexOf(value) < 0) {
-      answer_summary.case_set.push(value);
-    }
-  } else {
-    let index = answer_summary.case_set.indexOf(value);
-
-    if (index > -1) {
-      answer_summary.case_set.splice(index, 1);
-    }
-  }
-
-  let el = document.getElementById('selected_case_list');
-  let result = [];
-
-  render_selected_case_list(result, answer_summary);
-  el.innerHTML = result.join('');
-
-  el = document.getElementById('exported_cases_count');
-  el.innerHTML = `Cases to be included in export (${answer_summary.case_set.length}):`;
-
-  el = document.getElementById('case_result_pagination');
-  result = [];
-  render_pagination(result, g_case_view_request);
-  el.innerHTML = result.join('');
-
-  var summary_of_selected_cases = document.getElementById(
-    'summary_of_selected_cases'
-  );
-  summary_of_selected_cases.innerHTML = render_summary_of_selected_cases(
-    answer_summary
-  );
-}
-
-var g_case_view_request = {
-  total_rows: 0,
-  page: 1,
-  skip: 0,
-  take: 100,
-  sort: 'date_last_updated',
-  search_key: null,
-  descending: true,
-  get_query_string: function () {
-    var result = [];
-    result.push('?skip=' + (this.page - 1) * this.take);
-    result.push('take=' + this.take);
-    result.push('sort=' + this.sort);
-
-    if (this.search_key) {
-      result.push(
-        'search_key="' +
-          this.search_key.replace(/"/g, '\\"').replace(/\n/g, '\\n') +
-          '"'
-      );
-    }
-
-    result.push('descending=' + this.descending);
-
-    // console.log(this);
-
-    return result.join('&');
-  },
-};
-
-function get_case_set() {
-  var case_view_url =
-    location.protocol +
-    '//' +
-    location.host +
-    '/api/case_view' +
-    g_case_view_request.get_query_string();
-
-  $.ajax({
-    url: case_view_url,
-  }).done(function (case_view_response) {
-    let el = document.getElementById('search_result_list');
-    let html = [];
-    //html.push("<li><input type='checkbox' /> select all</li>");
-    g_case_view_request.total_rows = case_view_response.total_rows;
-    g_case_view_request.respone_rows = case_view_response.rows;
-    //g_case_view_request.page = case_view_response.page;
-
-    for (let i = 0; i < case_view_response.rows.length; i++) {
-      let item = case_view_response.rows[i];
-      let value_list = item.value;
-
-      selected_dictionary[item.id] = value_list;
-
-      let checked = '';
-      let index = answer_summary.case_set.indexOf(item.id);
-
-      if (index > -1) {
-        checked = 'checked=true';
-      }
-
-      // Items generated after user applies filters
-      html.push(`
-					<tr class="tr font-weight-normal">
-						<td class="td" data-type="date_created" width="38" align="center">
-							<input id=${escape(item.id)}
-										 type="checkbox"
-										 value=${escape(item.id)}
-										 type="checkbox"
-										 onclick="result_checkbox_click(this)" ${checked} />
-							<label for="" class="sr-only">${escape(item.id)}</label>
-						</td>
-						<td class="td" data-type="date_last_updated">
-							${escape(value_list.date_last_updated)
-                .replace(/%20/g, ' ')
-                .replace(/%3A/g, '-')} <br/> ${escape(
-        value_list.last_updated_by
-      )}
-						</td>
-						<td class="td" data-type="jurisdiction_id">
-							${escape(value_list.last_name)
-                .replace(/%20/g, ' ')
-                .replace(/%3A/g, '-')}, ${escape(value_list.first_name)
-        .replace(/%20/g, ' ')
-        .replace(/%3A/g, '-')} ${escape(value_list.middle_name)
-        .replace(/%20/g, ' ')
-        .replace(/%3A/g, '-')} [${escape(value_list.jurisdiction_id)}]  
-						</td>
-						<td class="td" data-type="record_id">
-							${escape(value_list.record_id).replace(/%20/g, ' ').replace(/%3A/g, '-')}
-						</td>
-						<td class="td" data-type="date_of_death">
-						${
-              value_list.date_of_death_year != null
-                ? escape(value_list.date_of_death_year)
-                : ''
-            }-${
-        value_list.date_of_death_month != null
-          ? escape(value_list.date_of_death_month)
-          : ''
-      }
-						</td>
-						<td class="td" data-type="committee_review_date">
-						${
-              value_list.committee_review_date != null
-                ? escape(value_list.committee_review_date)
-                : 'N/A'
-            }
-						</td>
-						<td class="td" data-type="agency_case_id">
-							${escape(value_list.agency_case_id).replace(/%20/g, ' ').replace(/%3A/g, '-')}
-						</td>
-						<td class="td" data-type="date_last_updated">
-							${escape(value_list.date_last_updated)
-                .replace(/%20/g, ' ')
-                .replace(/%3A/g, '-')}<br/>
-							${escape(value_list.created_by).replace(/%20/g, ' ').replace(/%3A/g, '-')}
-						</td>
-					</tr>
-				`);
-      // html.push(`<li class="foo"><input value=${escape(item.id)} type="checkbox" onclick="result_checkbox_click(this)" ${checked} /> ${escape(value_list.jurisdiction_id)} ${escape(value_list.last_name)},${escape(value_list.first_name)} ${escape(value_list.date_of_death_year)}/${escape(value_list.date_of_death_month)} ${escape(value_list.date_last_updated)} ${escape(value_list.last_updated_by)} agency_id:${escape(value_list.agency_case_id)} rc_id:${escape(value_list.record_id)}</li>`);
-    }
-
-    el.innerHTML = html.join('');
-
-    el = document.getElementById('case_result_pagination');
-    html = [];
-    render_pagination(html, g_case_view_request);
-    el.innerHTML = html.join('');
-  });
-}
-
-function render_selected_case_list(p_result, p_answer_summary) {
-  //html.push("<li><input type='checkbox' /> select all</li>");
-  for (let i = 0; i < p_answer_summary.case_set.length; i++) {
-    let item_id = p_answer_summary.case_set[i];
-    let value_list = selected_dictionary[item_id];
-
-    // Items generated after user ADDS applied filters
-    //html.push(`<li class="baz"><input value=${item_id} type="checkbox" onclick="result_checkbox_click(this)" checked="true" /> ${value_list.jurisdiction_id} ${value_list.last_name},${value_list.first_name} ${value_list.date_of_death_year}/${value_list.date_of_death_month} ${value_list.date_last_updated} ${value_list.last_updated_by} agency_id:${value_list.agency_case_id} rc_id:${value_list.record_id}</li>`);
-
-    let checked = '';
-    let index = p_answer_summary.case_set.indexOf(item_id);
-
-    if (index > -1) {
-      checked = 'checked=true';
-    }
-
-    // Items generated after user applies filters
-    p_result.push(`
-			<tr class="tr font-weight-normal">
-				<td class="td" data-type="date_created" width="38" align="center">
-					<input id=${escape(item_id)}
-								 type="checkbox"
-								 value=${escape(item_id)}
-								 type="checkbox"
-								 onclick="result_checkbox_click(this)" ${checked} />
-					<label for="" class="sr-only">${escape(item_id)}</label>
-				</td>
-				<td class="td" data-type="date_last_updated">
-					${escape(value_list.date_last_updated)
-            .replace(/%20/g, ' ')
-            .replace(/%3A/g, '-')} <br/> ${escape(value_list.last_updated_by)}
-				</td>
-				<td class="td" data-type="jurisdiction_id">
-					${escape(value_list.last_name)
-            .replace(/%20/g, ' ')
-            .replace(/%3A/g, '-')}, ${escape(value_list.first_name)
-      .replace(/%20/g, ' ')
-      .replace(/%3A/g, '-')} ${escape(value_list.middle_name)
-      .replace(/%20/g, ' ')
-      .replace(/%3A/g, '-')} [${escape(value_list.jurisdiction_id)}]  
-				</td>
-				<td class="td" data-type="record_id">
-					${escape(value_list.record_id).replace(/%20/g, ' ').replace(/%3A/g, '-')}
-				</td>
-				<td class="td" data-type="date_of_death">
-				${
-          value_list.date_of_death_year != null
-            ? escape(value_list.date_of_death_year)
-            : ''
-        }-${
-      value_list.date_of_death_month != null
-        ? escape(value_list.date_of_death_month)
-        : ''
-    }
-				</td>
-				<td class="td" data-type="committee_review_date">
-				${
-          value_list.committee_review_date != null
-            ? escape(value_list.committee_review_date)
-            : 'N/A'
-        }
-				</td>
-				<td class="td" data-type="agency_case_id">
-					${escape(value_list.agency_case_id).replace(/%20/g, ' ').replace(/%3A/g, '-')}
-				</td>
-				<td class="td" data-type="date_last_updated">
-					${escape(value_list.date_last_updated)
-            .replace(/%20/g, ' ')
-            .replace(/%3A/g, '-')}<br/>
-					${escape(value_list.created_by).replace(/%20/g, ' ').replace(/%3A/g, '-')}
-				</td>
-			</tr>
-		`);
   }
 }
 
@@ -1237,8 +790,6 @@ function render_selected_de_identified_list(p_result, p_answer_summary) {
 			</tr>
 		`);
   }
-
-  //el.innerHTML = html.join("");
 }
 
 function render_sort_by_include_in_export(p_case_view_request) {
@@ -1319,25 +870,6 @@ function de_identify_filter_type_click(p_value) {
     } else {
       reject();
     }
-
-    // if (!isNullOrUndefined(de_identify_filter)) {
-    // 	if(p_value.value.toLowerCase() == "custom")
-    // 	{
-    // 		de_identify_filter.style.display = "block";
-    // 	}
-    // 	else
-    // 	{
-    // 		de_identify_filter.style.display = "none";
-    // 	}
-
-    // 	answer_summary.de_identified_selection_type = p_value.value.toLowerCase()
-
-    // 	resolve();
-    // }
-    // else
-    // {
-    // 	reject();
-    // }
   });
 }
 
@@ -1345,55 +877,8 @@ function de_identify_search_text_change(p_value) {
   g_filter.search_text = p_value;
 }
 
-function filter_serach_text_change(p_value) {
-  g_case_view_request.search_key = p_value;
-}
-
 function de_identify_standard_fields_change(p_value) {
   answer_summary.is_de_identify_standard_fields = p_value;
-}
-
-function render_pagination(p_result, p_case_view_request) {
-  //p_result.push("<div id='case_result_pagination' class='table-pagination row align-items-center no-gutters'>");
-  p_result.push("<div class='col'>");
-  p_result.push("<div class='row no-gutters'>");
-  p_result.push("<p class='mb-0'>Total Records: ");
-  p_result.push('<strong>' + p_case_view_request.total_rows + '</strong>');
-  p_result.push('</p>');
-  p_result.push("<p class='mb-0 ml-2 mr-2'>|</p>");
-  p_result.push("<p class='mb-0'>Viewing Page(s): ");
-  p_result.push('<strong>' + p_case_view_request.page + '</strong> ');
-  p_result.push('of ');
-  p_result.push(
-    '<strong>' +
-      Math.ceil(p_case_view_request.total_rows / p_case_view_request.take) +
-      '</strong>'
-  );
-  p_result.push('</p>');
-  p_result.push('</div>');
-  p_result.push('</div>');
-  p_result.push(
-    "<div class='col row no-gutters align-items-center justify-content-end'>"
-  );
-  p_result.push("<p class='mb-0'>Select by page:</p>");
-  for (
-    let current_page = 1;
-    (current_page - 1) * p_case_view_request.take <
-    p_case_view_request.total_rows;
-    current_page++
-  ) {
-    p_result.push(
-      "<button type='button' class='table-btn-link btn btn-link' alt='select page " +
-        current_page +
-        "' onclick='g_ui.case_view_request.page="
-    );
-    p_result.push(current_page);
-    p_result.push(";get_case_set();'>");
-    p_result.push(current_page);
-    p_result.push('</button>');
-  }
-  p_result.push('</div>');
-  //p_result.push("</div>");
 }
 
 function render_summary_de_identified_fields(p_answer_summary) {

--- a/source-code/mmria/mmria-server/wwwroot/scripts/export-queue/index.js
+++ b/source-code/mmria/mmria-server/wwwroot/scripts/export-queue/index.js
@@ -1,6 +1,6 @@
 var g_metadata = null;
 var g_standard_de_identified_list = null;
-var g_look_up = {}
+var g_look_up = {};
 var g_data = null;
 var g_copy_clip_board = null;
 var g_delete_value_clip_board = null;
@@ -8,554 +8,448 @@ var g_delete_attribute_clip_board = null;
 var g_delete_node_clip_board = null;
 var g_current_version = null;
 
-
-var g_ui = { is_collapsed : [] };
-var g_filter = 	{
-	date_of_death:
-	{
-		year: [
-			'all'
-		],
-		month: [
-			'all'
-		],
-		day: [
-			'all'
-		],
-	},
-	date_range: [
-		{
-			from: 'all',
-			to:	'all'
-		}
-	],
-	case_status: [
-		'all'
-	],
-	case_jurisdiction: [
-		'/all'
-	],
-	selected_form: "",
-	search_text: ""
+var g_ui = { is_collapsed: [] };
+var g_filter = {
+  date_of_death: {
+    year: ['all'],
+    month: ['all'],
+    day: ['all'],
+  },
+  date_range: [
+    {
+      from: 'all',
+      to: 'all',
+    },
+  ],
+  case_status: ['all'],
+  case_jurisdiction: ['/all'],
+  selected_form: '',
+  search_text: '',
 };
 
 var selected_dictionary = {};
 var selected_metadata_dictionary = {};
 
-
 var answer_summary = {
-	all_or_core: 'all',
-	grantee_name: location.host,
-	is_encrypted: 'no',
-	zip_key: '',
-	is_for_cdc: 'no',
-	de_identified_selection_type: 'none',
-	de_identified_field_set: [],
-	is_de_identify_standard_fields: false,
-	case_filter_type: 'all',
-	case_set: []
+  all_or_core: 'all',
+  grantee_name: location.host,
+  is_encrypted: 'no',
+  zip_key: '',
+  is_for_cdc: 'no',
+  de_identified_selection_type: 'none',
+  de_identified_field_set: [],
+  is_de_identify_standard_fields: false,
+  case_filter_type: 'all',
+  case_set: [],
 };
 
-[ 'all', 'csv', 'none', location.host ];
+['all', 'csv', 'none', location.host];
 
-$(function ()
-{//http://www.w3schools.com/html/html_layout.asp
+$(function () {
+  //http://www.w3schools.com/html/html_layout.asp
   'use strict';
-	document.getElementById('form_content_id').innerHTML = "";
-	get_standard_de_identified_list();
-	
-	//update_queue_interval_id = window.setInterval(update_queue_task, 10000);
+  document.getElementById('form_content_id').innerHTML = '';
+  get_standard_de_identified_list();
+
+  //update_queue_interval_id = window.setInterval(update_queue_task, 10000);
 });
 
+function load_data() {
+  var url = location.protocol + '//' + location.host + '/api/export_queue';
 
-function load_data()
-{
-	var url =  location.protocol + '//' + location.host + '/api/export_queue'
+  $.ajax({
+    url: url,
+  }).done(function (response) {
+    g_data = [];
+    for (var i = 0; i < response.length; i++) {
+      if (response[i].status != 'Deleted' && response[i].status != 'expunged') {
+        g_data.push(response[i]);
+      }
+    }
 
-	$.ajax({
-			url: url
-	}).done(function(response) {
-			
-			g_data = [];
-			for(var i = 0; i < response.length; i++)
-			{
-				if
-				(
-					(response[i].status != "Deleted") &&
-					(response[i].status != "expunged")
-				)
-				{
-					g_data.push(response[i]);
-				}
-			}
-			
-			get_metadata();
-			
-			//document.getElementById('generate_report_button').disabled = false;
-			//process_rows();
-			//document.getElementById('navigation_id').innerHTML = navigation_render(g_user_list, 0, g_ui).join("");
+    get_metadata();
 
-			//document.getElementById('form_content_id').innerHTML = aggregate_report_render(g_ui, "", g_ui).join("");
+    //document.getElementById('generate_report_button').disabled = false;
+    //process_rows();
+    //document.getElementById('navigation_id').innerHTML = navigation_render(g_user_list, 0, g_ui).join("");
 
-	});
+    //document.getElementById('form_content_id').innerHTML = aggregate_report_render(g_ui, "", g_ui).join("");
+  });
 }
 
-
-function render()
-{
-
-	g_data.sort(function(a, b){return b.date_created-a.date_created});
-	document.getElementById('form_content_id').innerHTML = export_queue_render(g_data, answer_summary, g_filter).join("");
-	// render_answer_summary();
+function render() {
+  g_data.sort(function (a, b) {
+    return b.date_created - a.date_created;
+  });
+  document.getElementById('form_content_id').innerHTML = export_queue_render(
+    g_data,
+    answer_summary,
+    g_filter
+  ).join('');
+  // render_answer_summary();
 }
 
-function create_queue_item
-(
-	p_export_type,
-	p_all_or_core,
-	p_grantee_name,
-	p_is_encrypted,
-	p_zip_key,
-	p_de_identified_selection_type,
-	p_de_identified_field_set,
-	p_case_filter_type,
-	p_case_set,
-	p_de_identify_standard_fields
-)
-{
-	var new_date = new Date().toISOString();
-	var result = {
-			_id: new_date.replace(/:/g, "-") + ".zip",
-			date_created: new_date,
-			created_by: "",
-			date_last_updated: new_date,
-			last_updated_by: "",
-			file_name: new_date.replace(/:/g, "-") + ".zip",
-			export_type: p_export_type,
-			status: "Confirmation Required",
-			all_or_core: p_all_or_core,
-			grantee_name: p_grantee_name,
-			is_encrypted: p_is_encrypted,
-			zip_key: p_zip_key,
-			de_identified_selection_type: p_de_identified_selection_type,
-			de_identified_field_set: p_de_identified_field_set,
-			case_filter_type: p_case_filter_type,
-			case_set: p_case_set
+function create_queue_item(
+  p_export_type,
+  p_all_or_core,
+  p_grantee_name,
+  p_is_encrypted,
+  p_zip_key,
+  p_de_identified_selection_type,
+  p_de_identified_field_set,
+  p_case_filter_type,
+  p_case_set,
+  p_de_identify_standard_fields
+) {
+  var new_date = new Date().toISOString();
+  var result = {
+    _id: new_date.replace(/:/g, '-') + '.zip',
+    date_created: new_date,
+    created_by: '',
+    date_last_updated: new_date,
+    last_updated_by: '',
+    file_name: new_date.replace(/:/g, '-') + '.zip',
+    export_type: p_export_type,
+    status: 'Confirmation Required',
+    all_or_core: p_all_or_core,
+    grantee_name: p_grantee_name,
+    is_encrypted: p_is_encrypted,
+    zip_key: p_zip_key,
+    de_identified_selection_type: p_de_identified_selection_type,
+    de_identified_field_set: p_de_identified_field_set,
+    case_filter_type: p_case_filter_type,
+    case_set: p_case_set,
+  };
 
-	}
-	
-	if(result.all_or_core == "core")
-	{
-		result.export_type = "Core CSV";
-	}
+  if (result.all_or_core == 'core') {
+    result.export_type = 'Core CSV';
+  }
 
-	if
-	(
-		p_de_identify_standard_fields ||
-		result.de_identified_selection_type == "standard"
-	)
-	{
-		
-		for(let i in g_standard_de_identified_list.paths)
-		{
-			let item = g_standard_de_identified_list.paths[i];
+  if (
+    p_de_identify_standard_fields ||
+    result.de_identified_selection_type == 'standard'
+  ) {
+    for (let i in g_standard_de_identified_list.paths) {
+      let item = g_standard_de_identified_list.paths[i];
 
-			result.de_identified_field_set.push(item);
-		}
-	}
+      result.de_identified_field_set.push(item);
+    }
+  }
 
-	return result;
+  return result;
 }
 
-function custom_field_click()
-{
-	alert("you clicked to open the custom field interface. ")
+function custom_field_click() {
+  alert('you clicked to open the custom field interface. ');
 }
 
-function add_new_all_export_item()
-{
+function add_new_all_export_item() {
+  if (answer_summary.de_identify_standard_fields) {
+  }
 
-	if
-	(
-		answer_summary.de_identify_standard_fields
-	)
-	{
-		
-	}
+  let queue_item = create_queue_item(
+    'All CSV',
+    answer_summary.all_or_core,
+    answer_summary.grantee_name,
+    answer_summary.is_encrypted,
+    answer_summary.zip_key,
+    answer_summary.de_identified_selection_type,
+    answer_summary.de_identified_field_set,
+    answer_summary.case_filter_type,
+    answer_summary.case_set,
+    answer_summary.is_de_identify_standard_fields
+  );
 
-	let queue_item = create_queue_item
-		(
-			'All CSV',
-			answer_summary.all_or_core,
-			answer_summary.grantee_name,
-			answer_summary.is_encrypted,
-			answer_summary.zip_key,
-			answer_summary.de_identified_selection_type,
-			answer_summary.de_identified_field_set,
-			answer_summary.case_filter_type,
-			answer_summary.case_set,
-			answer_summary.is_de_identify_standard_fields
-		);
-	
+  g_data.push(queue_item);
 
-	g_data.push
-	(
-		queue_item
-	);
+  confirm_export_item(queue_item._id);
 
-	confirm_export_item(queue_item._id);
-
-	//render();
-
+  //render();
 }
 
-function find_export_item(p_id)
-{
-	var result = null;
-	for(var i = 0; i < g_data.length; i++)
-	{
-		if(g_data[i]._id == p_id)
-		{
-			result = g_data[i];
-			break;	
-		}
-	}
+function find_export_item(p_id) {
+  var result = null;
+  for (var i = 0; i < g_data.length; i++) {
+    if (g_data[i]._id == p_id) {
+      result = g_data[i];
+      break;
+    }
+  }
 
-	return result;
+  return result;
 }
 
-function confirm_export_item(p_id)
-{
-	// submit queue item
-	var item = find_export_item(p_id);
-	if(item)
-	{
-		item.status = "In Queue...";
-		item.date_last_updated = new Date().toISOString();
-		item.last_updated_by = "";
+function confirm_export_item(p_id) {
+  // submit queue item
+  var item = find_export_item(p_id);
+  if (item) {
+    item.status = 'In Queue...';
+    item.date_last_updated = new Date().toISOString();
+    item.last_updated_by = '';
 
-		var export_queue_url = location.protocol + '//' + location.host + '/api/export_queue';
+    var export_queue_url =
+      location.protocol + '//' + location.host + '/api/export_queue';
 
-		$.ajax({
-				url: export_queue_url,
-				contentType: 'application/json; charset=utf-8',
-				dataType: 'json',
-				data: JSON.stringify(item),
-				type: "POST"
-				/*,
+    $.ajax({
+      url: export_queue_url,
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      data: JSON.stringify(item),
+      type: 'POST',
+      /*,
 
 				beforeSend: function (request)
 				{
 					request.setRequestHeader("AuthSession", $mmria.getCookie("AuthSession"));
 				}/*/
-		}).done(function(response) {
+    }).done(function (response) {
+      render();
 
-			render();
+      if (update_queue_interval_id == null) {
+        update_queue_interval_id = window.setInterval(update_queue_task, 10000);
+        update_queue_interval_count = 1;
+      } else {
+        update_queue_interval_count += 1;
+      }
 
-			if(update_queue_interval_id == null)
-			{ 
-				update_queue_interval_id = window.setInterval(update_queue_task, 10000);
-				update_queue_interval_count = 1;
-			}
-			else
-			{
-				update_queue_interval_count += 1;
-			}
-		
-				//g_metadata = response;
-				//load_data(g_uid, $mmria.getCookie("pwd"));
-		});
-	}
-	
+      //g_metadata = response;
+      //load_data(g_uid, $mmria.getCookie("pwd"));
+    });
+  }
 }
 
-function cancel_export_item(p_id)
-{
-	for(var i = 0; i < g_data.length; i++)
-	{
-		if(g_data[i]._id == p_id)
-		{
-			g_data.splice(i, 1);
-			break;	
-		}
-	}
-	render();
+function cancel_export_item(p_id) {
+  for (var i = 0; i < g_data.length; i++) {
+    if (g_data[i]._id == p_id) {
+      g_data.splice(i, 1);
+      break;
+    }
+  }
+  render();
 }
 
-function download_export_item(p_id)
-{
-	var item = find_export_item(p_id);
-	if(item)
-	{
-		var download_url = location.protocol + '//' + location.host + '/api/zip/' + p_id;
-		window.open(download_url, "_zip");
-		load_data();
+function download_export_item(p_id) {
+  var item = find_export_item(p_id);
+  if (item) {
+    var download_url =
+      location.protocol + '//' + location.host + '/api/zip/' + p_id;
+    window.open(download_url, '_zip');
+    load_data();
 
-		if
-		(
-			update_queue_interval_id != null && 
-			update_queue_interval_count > 0
-		)
-		{
-			update_queue_interval_count-= 1;
+    if (update_queue_interval_id != null && update_queue_interval_count > 0) {
+      update_queue_interval_count -= 1;
 
-			if(update_queue_interval_count == 0)
-			{
-				clearInterval(update_queue_interval_id);
-				update_queue_interval_id = null;
-			}
-			
-		}
-		window.setTimeout(update_queue_task, 2000);
-		render();
-	}
+      if (update_queue_interval_count == 0) {
+        clearInterval(update_queue_interval_id);
+        update_queue_interval_id = null;
+      }
+    }
+    window.setTimeout(update_queue_task, 2000);
+    render();
+  }
 }
 
-function delete_export_item(p_id)
-{
-	var item = find_export_item(p_id);
-	if(item)
-	{
-		item.status = "Deleted";
-		item.date_last_updated = new Date().toISOString();
-		item.last_updated_by = "";
-		//item._deleted = true;
-		var export_queue_url = location.protocol + '//' + location.host + '/api/export_queue';
+function delete_export_item(p_id) {
+  var item = find_export_item(p_id);
+  if (item) {
+    item.status = 'Deleted';
+    item.date_last_updated = new Date().toISOString();
+    item.last_updated_by = '';
+    //item._deleted = true;
+    var export_queue_url =
+      location.protocol + '//' + location.host + '/api/export_queue';
 
-		$.ajax({
-				url: export_queue_url,
-				contentType: 'application/json; charset=utf-8',
-				dataType: 'json',
-				data: JSON.stringify(item),
-				type: "POST",
-				beforeSend: function (request)
-				{
-					request.setRequestHeader("AuthSession", $mmria.getCookie("AuthSession"));
-				}//,
-		}).done(function(response) {
-				//g_metadata = response;
-				load_data();
-		});
-	}
+    $.ajax({
+      url: export_queue_url,
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      data: JSON.stringify(item),
+      type: 'POST',
+      beforeSend: function (request) {
+        request.setRequestHeader(
+          'AuthSession',
+          $mmria.getCookie('AuthSession')
+        );
+      }, //,
+    }).done(function (response) {
+      //g_metadata = response;
+      load_data();
+    });
+  }
 }
-
-
 
 let update_queue_interval_id = null;
 let update_queue_interval_count = 0;
 
-function update_queue_task()
-{
-	var temp = [];
+function update_queue_task() {
+  var temp = [];
 
-	if(g_data == null)
-	{
-		return;
-	}
+  if (g_data == null) {
+    return;
+  }
 
-	for(var i = 0; i < g_data.length; i++)
-	{
-		if(g_data[i].status == "Confirmation Required")
-		{
-			temp.push(g_data[i]);
-		}
-	}
+  for (var i = 0; i < g_data.length; i++) {
+    if (g_data[i].status == 'Confirmation Required') {
+      temp.push(g_data[i]);
+    }
+  }
 
-	var url =  location.protocol + '//' + location.host + '/api/export_queue';
+  var url = location.protocol + '//' + location.host + '/api/export_queue';
 
-	$.ajax({
-			url: url
-	}).done(function(response) {
-			
-			g_data = [];
-			for(var i = 0; i < response.length; i++)
-			{
-				if
-				(
-					(response[i].status != "Deleted") &&
-					response[i].status != "expunged"
-				)
-				{
-					g_data.push(response[i]);
-				}
-			}
-			
-			for(var i = 0; i < temp.length; i++)
-			{
-				g_data.push(temp[i]);
-			}
+  $.ajax({
+    url: url,
+  })
+    .done(function (response) {
+      g_data = [];
+      for (var i = 0; i < response.length; i++) {
+        if (
+          response[i].status != 'Deleted' &&
+          response[i].status != 'expunged'
+        ) {
+          g_data.push(response[i]);
+        }
+      }
 
+      for (var i = 0; i < temp.length; i++) {
+        g_data.push(temp[i]);
+      }
 
-			render();
+      render();
 
-			//document.getElementById('generate_report_button').disabled = false;
-			//process_rows();
-			//document.getElementById('navigation_id').innerHTML = navigation_render(g_user_list, 0, g_ui).join("");
+      //document.getElementById('generate_report_button').disabled = false;
+      //process_rows();
+      //document.getElementById('navigation_id').innerHTML = navigation_render(g_user_list, 0, g_ui).join("");
 
-			//document.getElementById('form_content_id').innerHTML = aggregate_report_render(g_ui, "", g_ui).join("");
-
-	})
-	.fail(function(jqXHR, textStatus, errorThrown)
-	{
-
-
-		if
-		(
-			update_queue_interval_id != null 
-		)
-		{
-			update_queue_interval_count =0;
-			clearInterval(update_queue_interval_id);
-			update_queue_interval_id = null;
-		}
-/*
+      //document.getElementById('form_content_id').innerHTML = aggregate_report_render(g_ui, "", g_ui).join("");
+    })
+    .fail(function (jqXHR, textStatus, errorThrown) {
+      if (update_queue_interval_id != null) {
+        update_queue_interval_count = 0;
+        clearInterval(update_queue_interval_id);
+        update_queue_interval_id = null;
+      }
+      /*
 		switch(errorThrown)
 		{
 
 		}*/
-	});
+    });
 }
 
-function zip_key_changed(p_value)
-{
-	answer_summary.zip_key = p_value;
+function zip_key_changed(p_value) {
+  answer_summary.zip_key = p_value;
 }
 
-function setAnswerSummary(event) 
-{
-	return new Promise
-	(
-		(resolve, reject) => {
-		const target = event.target;
-		const val = target.value;
-		const prop = target.dataset.prop;
-		let path; 
+function setAnswerSummary(event) {
+  return new Promise((resolve, reject) => {
+    const target = event.target;
+    const val = target.value;
+    const prop = target.dataset.prop;
+    let path;
 
-		//console.log(target, val, prop);
-		
-		if (prop) 
-		{
-			if (prop.indexOf('/') < 0) 
-			{
-				answer_summary[prop] = val;
-			}
-			else 
-			{
-				path = prop.split('/');
-				switch(path[1])
-				{
-					case 'date_of_death':
-						switch(path[2]) 
-						{
-							case 'year':
-								answer_summary['filter']['date_of_death']['year'][0] = val;
-								break;
-							case 'month':
-								answer_summary['filter']['date_of_death']['month'][0] = val;
-								break;
-							case 'day':
-								answer_summary['filter']['date_of_death']['day'][0] = val;
-								break;
-						}
-						break;
-					case 'case_status':
-						let case_opts = target.options;
-						let statuses = [];
-						for (let i = 0; i< case_opts.length; i++) {
-							if (case_opts[i].selected) {
-								// push each selected option into statuses arr
-								statuses.push(case_opts[i].value);
-								
-								// // Below we push obj into temp 'statuses' array for later manipulation
-								// let s = {};
-								// s['value'] = case_opts[i].value;
-								// s['text'] = case_opts[i].text;
-								// statuses.push(status);
-							}
-						}
-						// set answer_summary to new statuses
-						answer_summary['filter']['case_status'] = statuses;
-						break;
-					case 'case_jurisdiction':
-							let jurisdiction_opts = target.options;
-							let jurisdictions = [];
-							for (let i = 0; i< jurisdiction_opts.length; i++) {
-								if (jurisdiction_opts[i].selected) {
-									// push each selected option into jurisdictions arr
-									jurisdictions.push(jurisdiction_opts[i].value);
-									
-									// let j = {};
-									// // Below we push obj into temp 'jurisdictions' array for later manipulation
-									// j['value'] = jurisdiction_opts[i].value;
-									// j['text'] = jurisdiction_opts[i].text;
-									// jurisdictions.push(j);
-								}
-							}
-							// set answer_summary to new jurisdictions
-							answer_summary['filter']['case_jurisdiction'] = jurisdictions;
-						break;
-				}
-			}
-			//console.log('Updating... ', answer_summary);
-			resolve();
-		}
-		else
-		{
-			reject('Error');
-		}
-	});
+    //console.log(target, val, prop);
+
+    if (prop) {
+      if (prop.indexOf('/') < 0) {
+        answer_summary[prop] = val;
+      } else {
+        path = prop.split('/');
+        switch (path[1]) {
+          case 'date_of_death':
+            switch (path[2]) {
+              case 'year':
+                answer_summary['filter']['date_of_death']['year'][0] = val;
+                break;
+              case 'month':
+                answer_summary['filter']['date_of_death']['month'][0] = val;
+                break;
+              case 'day':
+                answer_summary['filter']['date_of_death']['day'][0] = val;
+                break;
+            }
+            break;
+          case 'case_status':
+            let case_opts = target.options;
+            let statuses = [];
+            for (let i = 0; i < case_opts.length; i++) {
+              if (case_opts[i].selected) {
+                // push each selected option into statuses arr
+                statuses.push(case_opts[i].value);
+
+                // // Below we push obj into temp 'statuses' array for later manipulation
+                // let s = {};
+                // s['value'] = case_opts[i].value;
+                // s['text'] = case_opts[i].text;
+                // statuses.push(status);
+              }
+            }
+            // set answer_summary to new statuses
+            answer_summary['filter']['case_status'] = statuses;
+            break;
+          case 'case_jurisdiction':
+            let jurisdiction_opts = target.options;
+            let jurisdictions = [];
+            for (let i = 0; i < jurisdiction_opts.length; i++) {
+              if (jurisdiction_opts[i].selected) {
+                // push each selected option into jurisdictions arr
+                jurisdictions.push(jurisdiction_opts[i].value);
+
+                // let j = {};
+                // // Below we push obj into temp 'jurisdictions' array for later manipulation
+                // j['value'] = jurisdiction_opts[i].value;
+                // j['text'] = jurisdiction_opts[i].text;
+                // jurisdictions.push(j);
+              }
+            }
+            // set answer_summary to new jurisdictions
+            answer_summary['filter']['case_jurisdiction'] = jurisdictions;
+            break;
+        }
+      }
+      //console.log('Updating... ', answer_summary);
+      resolve();
+    } else {
+      reject('Error');
+    }
+  });
 }
 
+function get_metadata() {
+  $.ajax({
+    url: location.protocol + '//' + location.host + '/api/metadata',
+  }).done(function (response) {
+    g_metadata = response;
 
-function get_metadata()
-{
-  $.ajax
-  ({
-			url: location.protocol + '//' + location.host + '/api/metadata',
-  })
-  .done(function(response) 
-  {
-		g_metadata = response;
+    for (var i in g_metadata.lookup) {
+      var child = g_metadata.lookup[i];
 
-		for(var i in g_metadata.lookup)
-		{
-			var child = g_metadata.lookup[i];
+      g_look_up['lookup/' + child.name] = child.values;
+    }
 
-			g_look_up["lookup/" + child.name] = child.values;
-		}
+    render();
 
-
-
-		render();		
-
-		update_queue_task();
-	
-
-	});
+    update_queue_task();
+  });
 }
 
-function get_standard_de_identified_list()
-{
+function get_standard_de_identified_list() {
+  $.ajax({
+    url:
+      location.protocol +
+      '//' +
+      location.host +
+      '/api/de_identified_list?id=export',
+  }).done(function (response) {
+    g_standard_de_identified_list = response;
 
-	$.ajax({
-		url: location.protocol + '//' + location.host + '/api/de_identified_list?id=export',
-	}).done(function(response) 
-	{
-		g_standard_de_identified_list = response;
-
-		load_data();
-		
-	});
-
+    load_data();
+  });
 }
 
-function get_latest_version()
-{
-
-  	$.ajax({
-
-            url: location.protocol + '//' + location.host + `/api/version/latest`
-	}).done(function(response) {
-		g_current_version = response;
-	});
+function get_latest_version() {
+  $.ajax({
+    url: location.protocol + '//' + location.host + `/api/version/latest`,
+  }).done(function (response) {
+    g_current_version = response;
+  });
 }

--- a/source-code/mmria/mmria-server/wwwroot/scripts/export-queue/index.js
+++ b/source-code/mmria/mmria-server/wwwroot/scripts/export-queue/index.js
@@ -86,6 +86,7 @@ function render() {
     answer_summary,
     g_filter
   ).join('');
+  renderReactExportQueue(answer_summary);
   // render_answer_summary();
 }
 
@@ -163,8 +164,6 @@ function add_new_all_export_item() {
   g_data.push(queue_item);
 
   confirm_export_item(queue_item._id);
-
-  //render();
 }
 
 function find_export_item(p_id) {
@@ -427,7 +426,6 @@ function get_metadata() {
     }
 
     render();
-
     update_queue_task();
   });
 }


### PR DESCRIPTION
This does not include the fix that was requested by Jill and Joan to have everything select all by default. There were some other logic to  consider regarding pagination before we can handle that. See the feature #75855 in TFS for more details.

The refactor approach below integrates react into our current workflow. `ReactDom.render()` is being called via a callback in the `render()` function found in `wwwroot/scripts/export-queue/index.js`. You'll find `renderReactExportQueue` function at the bottom of `wwwroot/reactjs/ExportQueue/exportqueue.jsx` this is the entry point to the app. Here `ReactDom.render()` is rendering react with in the `li` with the `id="react-content"` which was previously rendered by the function `export_queue_render` in `wwwroot/scripts/export-queue/export-queue.js`

There are some files below that were autoformatted by VSCode. I'm not sure if everyone else is formatting on save...